### PR TITLE
Generate man pages and bash completion

### DIFF
--- a/internal/util.go
+++ b/internal/util.go
@@ -1,0 +1,46 @@
+package yggdrasil
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/urfave/cli/v2"
+)
+
+// BashCompleteCommand prints all visible flag options for the given command,
+// and then recursively calls itself on each subcommand.
+func BashCompleteCommand(cmd *cli.Command, w io.Writer) {
+	for _, name := range cmd.Names() {
+		fmt.Fprintf(w, "%v\n", name)
+	}
+
+	PrintFlagNames(cmd.VisibleFlags(), w)
+
+	for _, command := range cmd.Subcommands {
+		BashCompleteCommand(command, w)
+	}
+}
+
+// PrintFlagNames prints the long and short names of each flag in the slice.
+func PrintFlagNames(flags []cli.Flag, w io.Writer) {
+	for _, flag := range flags {
+		for _, name := range flag.Names() {
+			if len(name) > 1 {
+				fmt.Fprintf(w, "--%v\n", name)
+			} else {
+				fmt.Fprintf(w, "-%v\n", name)
+			}
+		}
+	}
+}
+
+// BashComplete prints all commands, subcommands and flags to the application
+// writer.
+func BashComplete(c *cli.Context) {
+	for _, command := range c.App.VisibleCommands() {
+		BashCompleteCommand(command, c.App.Writer)
+
+		// global flags
+		PrintFlagNames(c.App.VisibleFlags(), c.App.Writer)
+	}
+}


### PR DESCRIPTION
Add two hidden flags, `--generate-man-page` and `--generate-markdown`, to `ygg` and `yggd`. They produce man pages and a general markdown "USAGE" file for documentation. Also add a bash completion function to produce bash completion hints.