### PR TITLE
feat: New config option: data-host

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,8 @@ PKGNAME   := yggdrasil
 VERSION   := 0.1.2
 # Used as the prefix for MQTT topic names
 TOPICPREFIX := yggdrasil
+# Used to force sending all HTTP traffic to a specific host.
+DATAHOST := 
 
 # Installation directories
 PREFIX        ?= /usr/local
@@ -54,6 +56,7 @@ LDFLAGS += -X 'github.com/redhatinsights/yggdrasil.ManDir=$(MANDIR)'
 LDFLAGS += -X 'github.com/redhatinsights/yggdrasil.DocDir=$(DOCDIR)'
 LDFLAGS += -X 'github.com/redhatinsights/yggdrasil.LocalstateDir=$(LOCALSTATEDIR)'
 LDFLAGS += -X 'github.com/redhatinsights/yggdrasil.TopicPrefix=$(TOPICPREFIX)'
+LDFLAGS += -X 'github.com/redhatinsights/yggdrasil.DataHost=$(DATAHOST)'
 
 BUILDFLAGS :=
 ifeq ($(shell find . -name vendor), ./vendor)
@@ -105,6 +108,7 @@ data: $(DATA)
 		-e 's,[@]VERSION[@],$(VERSION),g' \
 		-e 's,[@]PACKAGE[@],$(PACKAGE),g' \
 		-e 's,[@]TOPICPREFIX[@],$(TOPICPREFIX),g' \
+		-e 's,[@]DATAHOST[@],$(DATAHOST),g' \
 		-e 's,[@]PREFIX[@],$(PREFIX),g' \
 		-e 's,[@]BINDIR[@],$(BINDIR),g' \
 		-e 's,[@]SBINDIR[@],$(SBINDIR),g' \

--- a/cmd/yggd/main.go
+++ b/cmd/yggd/main.go
@@ -67,6 +67,11 @@ func main() {
 			Name:   "generate-markdown",
 			Hidden: true,
 		},
+		altsrc.NewStringFlag(&cli.StringFlag{
+			Name:  "data-host",
+			Usage: "Force all HTTP traffic over `HOST`",
+			Value: yggdrasil.DataHost,
+		}),
 	}
 
 	// This BeforeFunc will load flag values from a config file only if the
@@ -141,7 +146,7 @@ func main() {
 			return cli.Exit(err, 1)
 		}
 
-		dataProcessor, err := yggdrasil.NewDataProcessor(db, c.String("cert-file"), c.String("key-file"))
+		dataProcessor, err := yggdrasil.NewDataProcessor(db, c.String("cert-file"), c.String("key-file"), c.String("data-host"))
 		if err != nil {
 			return cli.Exit(err, 1)
 		}

--- a/constants.go
+++ b/constants.go
@@ -17,6 +17,9 @@ var (
 
 	// TopicPrefix is used as a prefix to all MQTT topics in the client.
 	TopicPrefix string
+
+	// DataHost is used to force sending all HTTP traffic to a specific host.
+	DataHost string
 )
 
 // Installation directory prefix and paths. Values are specified by compile-time

--- a/yggdrasil.spec.rpkg
+++ b/yggdrasil.spec.rpkg
@@ -12,6 +12,7 @@
 
 %if "%{brand_name}" == "rhc"
 %global topic_prefix redhat/insights
+%global data_host cert.cloud.redhat.com
 %else
 %global topic_prefix {{{ git_dir_name }}}
 %endif
@@ -51,7 +52,8 @@ make PREFIX=%{_prefix} \
      PKGNAME=%{pkg_name} \
      BRANDNAME=%{brand_name} \
      TOPICPREFIX=%{topic_prefix} \
-     VERSION=%{version}
+     VERSION=%{version} \
+     DATAHOST=%{data_host}
 
 
 %install
@@ -65,6 +67,7 @@ make PREFIX=%{_prefix} \
      BRANDNAME=%{brand_name} \
      TOPICPREFIX=%{topic_prefix} \
      VERSION=%{version} \
+     DATAHOST=%{data_host} \
      install
 
 


### PR DESCRIPTION
If set to a non-empty string, the data-host config option will force all HTTP traffic sent by the `DataProcessor` through the specified host. When `DataProcessor` is processing a message, if the worker has `detachedContent` set to `true`, the value of the message's `content` field is parsed as a URL and the value of the URL's `Host` field is set to the value specified by the data-host argument before sending the HTTP request to the HTTP client for handling.

If no value is set in either the config file or on the command line, a compile-time constant, `DataHost` is set as the default value. In any case, if the value of `DataHost` is an empty string, no host substitution is performed.

Fixes RHCLOUD-12548