### PR TITLE
Add hidden --topic-prefix option

### DIFF
--- a/cmd/yggd/main.go
+++ b/cmd/yggd/main.go
@@ -44,11 +44,11 @@ func main() {
 			Name:  "key-file",
 			Usage: "Use `FILE` as the client's private key",
 		}),
-		&cli.StringFlag{
+		altsrc.NewStringFlag(&cli.StringFlag{
 			Name:   "ca-root",
 			Hidden: true,
 			Usage:  "Use `FILE` as the root CA",
-		},
+		}),
 		altsrc.NewStringFlag(&cli.StringFlag{
 			Name:   "topic-prefix",
 			Value:  yggdrasil.TopicPrefix,

--- a/cmd/yggd/main.go
+++ b/cmd/yggd/main.go
@@ -49,6 +49,12 @@ func main() {
 			Hidden: true,
 			Usage:  "Use `FILE` as the root CA",
 		},
+		altsrc.NewStringFlag(&cli.StringFlag{
+			Name:   "topic-prefix",
+			Value:  yggdrasil.TopicPrefix,
+			Hidden: true,
+			Usage:  "Use `PREFIX` as the MQTT topic prefix",
+		}),
 		altsrc.NewStringSliceFlag(&cli.StringSliceFlag{
 			Name:  "broker",
 			Usage: "Connect to the broker specified in `URI`",
@@ -93,6 +99,11 @@ func main() {
 			fmt.Println(data)
 			return nil
 		}
+
+		if c.String("topic-prefix") != "" {
+			yggdrasil.TopicPrefix = c.String("topic-prefix")
+		}
+
 		level, err := log.ParseLevel(c.String("log-level"))
 		if err != nil {
 			return cli.NewExitError(err, 1)


### PR DESCRIPTION
A new --topic-prefix option enables the default topic prefix to be overridden at run time. This value can be set either in the config file or via the command-line option. This option really only exists for QE, so it's hidden and undocumented intentionally.