### PR TITLE
fix: Fix subcommand name for register/connect

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ calling `WatchForProcesses`.
 
 ### `./cmd/ygg`
 
-`ygg` is a specialized RHSM client. When run with the `register` subcommand, it
+`ygg` is a specialized RHSM client. When run with the `connect` subcommand, it
 attempts to register with RHSM over D-Bus. If registration is successful, it
 activates the `yggd` systemd service.
 


### PR DESCRIPTION
Fix the subcommand name in README.md for starting the registration
procedure from register to connect.

Signed-off-by: Patrick Uiterwijk <patrick@puiterwijk.org>