### PR TITLE
fix: delete messages after dispatch

### DIFF
--- a/cmd/yggd/main.go
+++ b/cmd/yggd/main.go
@@ -116,6 +116,10 @@ func main() {
 		log.SetLevel(level)
 		log.SetPrefix(fmt.Sprintf("[%v] ", app.Name))
 
+		if level >= log.LevelDebug {
+			log.SetFlags(log.LstdFlags | log.Llongfile)
+		}
+
 		log.Infof("starting %v version %v", app.Name, app.Version)
 
 		quit := make(chan os.Signal, 1)

--- a/data_processor.go
+++ b/data_processor.go
@@ -187,7 +187,7 @@ func (p *DataProcessor) HandleDataReturnSignal(c <-chan interface{}) {
 				p.logger.Error(err)
 				return
 			}
-			if obj != nil {
+			if obj == nil {
 				URL, err := url.Parse(dataMessage.Directive)
 				if err != nil {
 					p.logger.Error(err)

--- a/dispatcher.go
+++ b/dispatcher.go
@@ -292,6 +292,13 @@ func (d *Dispatcher) HandleDataProcessSignal(c <-chan interface{}) {
 				return
 			}
 
+			tx = d.db.Txn(true)
+			if err := tx.Delete(tableNameData, dataMessage); err != nil {
+				d.logger.Error(err)
+				return
+			}
+			tx.Commit()
+
 			d.sig.emit(SignalDataDispatch, dataMessage.MessageID)
 			d.logger.Debugf("emitted signal \"%v\"", SignalDataDispatch)
 			d.logger.Tracef("emitted value: %#v", dataMessage.MessageID)

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/redhatinsights/yggdrasil
 go 1.13
 
 require (
-	git.sr.ht/~spc/go-log v0.0.0-20201023160325-a0ff5c6cd86b
+	git.sr.ht/~spc/go-log v0.0.0-20210409014304-ce6a6f3602dc
 	github.com/briandowns/spinner v1.12.0
 	github.com/coreos/go-systemd/v22 v22.1.0
 	github.com/cpuguy83/go-md2man/v2 v2.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,8 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 git.sr.ht/~spc/go-log v0.0.0-20201023160325-a0ff5c6cd86b h1:vy0WIbDtJBccHi3MLC7FotVVt7ut97Txx6+6KfnyIOo=
 git.sr.ht/~spc/go-log v0.0.0-20201023160325-a0ff5c6cd86b/go.mod h1:IKiYUc0lWbZO4uSV0kWNzJSFnABNdrybpPWo46CGgFM=
+git.sr.ht/~spc/go-log v0.0.0-20210409014304-ce6a6f3602dc h1:jrsDG/OBvZz/ToHTMIsWXTQ0L1N7A8XGx77aifPethE=
+git.sr.ht/~spc/go-log v0.0.0-20210409014304-ce6a6f3602dc/go.mod h1:IKiYUc0lWbZO4uSV0kWNzJSFnABNdrybpPWo46CGgFM=
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/briandowns/spinner v1.12.0 h1:72O0PzqGJb6G3KgrcIOtL/JAGGZ5ptOMCn9cUHmqsmw=


### PR DESCRIPTION
When a message is dispatched to a worker, it is deleted from the internal memory store. When data is received from a worker, rather than looking up the original message to identify the worker that sent it, the new message is added to the memory store. The DataProcessor then attempts to parse the directive as a URL; if that succeeds (where "succeeds" in this case means the parsed value includes a valid URL scheme component), the message/worker is treated as a detachedContent worker and the data is return via HTTP.

Fixes RHCLOUD-12336

Signed-off-by: Link Dupont <link@sub-pop.net>