### PR TITLE
BIOSUUID can be the empty string if sysfs doesn't provide one

### DIFF
--- a/canonical_facts.go
+++ b/canonical_facts.go
@@ -120,9 +120,12 @@ func GetCanonicalFacts() (*CanonicalFacts, error) {
 		return nil, err
 	}
 
-	facts.BIOSUUID, err = readFile("/sys/devices/virtual/dmi/id/product_uuid")
-	if err != nil {
-		return nil, err
+	if _, err := os.Stat("/sys/devices/virtual/dmi/id/product_uuid"); !os.IsNotExist(err) {
+		BIOSUUID, err := readFile("/sys/devices/virtual/dmi/id/product_uuid")
+		if err != nil {
+			return nil, err
+		}
+		facts.BIOSUUID = BIOSUUID
 	}
 
 	facts.SubscriptionManagerID, err = readCert("/etc/pki/consumer/cert.pem")


### PR DESCRIPTION
Signed-off-by: Adam Miller <admiller@redhat.com>