### PR TITLE
Support custom "srpm" builds in COPR

### DIFF
--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -1,0 +1,52 @@
+include Makefile
+
+SOURCEDIR := $(shell rpmbuild -E %_sourcedir)
+SRCRPMDIR := $(shell rpmbuild -E %_srcrpmdir)
+
+srpm: SHORTNAME = $(shell basename $(PWD))
+srpm: LONGNAME = $(SHORTNAME)
+srpm: BRANDNAME = $(SHORTNAME)
+srpm: VERSION = $(shell git describe --tags --abbrev=0)
+srpm: RELEASE = $(shell printf "0.%s.git.%s" $(shell git rev-list $(shell git describe --tags --abbrev=0 | tr -d '\n')..HEAD --count | tr -d '\n') $(shell git rev-parse --short HEAD | tr -d '\n'))
+srpm: PKGNAME = $(SHORTNAME)
+
+ifeq ($(shell git rev-parse --abbrev-ref HEAD), main)
+sprm: VERSION = $(shell git describe --tags --abbrev=0 | awk -F. '{printf("%d.%d.%d", $1, $2, $3+1)}')
+endif
+
+ifeq ($(shell basename $(PWD)), rhc)
+srpm: TOPICPREFIX = redhat/insights
+srpm: DATAHOST = cert.cloud.redhat.com
+else
+srpm: TOPICPREFIX = $(SHORTNAME)
+srpm: DATAHOST = ""
+endif
+
+.PHONY: srpm
+srpm: deps
+	sed \
+	    -e 's,[@]SHORTNAME[@],$(SHORTNAME),g' \
+		-e 's,[@]LONGNAME[@],$(LONGNAME),g' \
+		-e 's,[@]BRANDNAME[@],$(BRANDNAME),g' \
+		-e 's,[@]VERSION[@],$(VERSION),g' \
+		-e 's,[@]RELEASE[@],$(RELEASE),g' \
+		-e 's,[@]PKGNAME[@],$(PKGNAME),g' \
+		-e 's,[@]TOPICPREFIX[@],$(TOPICPREFIX),g' \
+		-e 's,[@]DATAHOST[@],$(DATAHOST),g' \
+		-e 's,[@]PREFIX[@],$(PREFIX),g' \
+		-e 's,[@]BINDIR[@],$(BINDIR),g' \
+		-e 's,[@]SBINDIR[@],$(SBINDIR),g' \
+		-e 's,[@]LIBEXECDIR[@],$(LIBEXECDIR),g' \
+		-e 's,[@]DATAROOTDIR[@],$(DATAROOTDIR),g' \
+		-e 's,[@]DATADIR[@],$(DATADIR),g' \
+		-e 's,[@]SYSCONFDIR[@],$(SYSCONFDIR),g' \
+		-e 's,[@]LOCALSTATEDIR[@],$(LOCALSTATEDIR),g' \
+		-e 's,[@]DOCDIR[@],$(DOCDIR),g' \
+		yggdrasil.spec.in > yggdrasil.spec.tmp && mv yggdrasil.spec.tmp yggdrasil.spec
+	make PKGNAME=$(PKGNAME) VERSION=$(VERSION)-$(RELEASE) dist
+	install -D -m644 $(PKGNAME)-$(VERSION)-$(RELEASE).tar.gz $(SOURCEDIR)/
+	rpmbuild -bs $(spec)/yggdrasil.spec
+	install -D -m644 $(SRCRPMDIR)/*.rpm $(outdir)/
+
+deps:
+	dnf install -y golang git

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 /yggd-USAGE.md
 /yggd.1.gz
 /yggd.bash
+/yggdrasil.spec

--- a/yggdrasil.spec.in
+++ b/yggdrasil.spec.in
@@ -5,27 +5,15 @@
 
 %define debug_package %{nil}
 
-%global long_name  {{{ git_dir_name }}}
-%global short_name %(s={{{ git_dir_name }}}; echo ${s:0:3})
-%global pkg_name   {{{ git_dir_name }}}
-%global brand_name   {{{ git_dir_name }}}
 
-%if "%{brand_name}" == "rhc"
-%global topic_prefix redhat/insights
-%global data_host cert.cloud.redhat.com
-%else
-%global topic_prefix {{{ git_dir_name }}}
-%endif
-
-Name:    {{{ git_dir_name }}}
-Version: {{{ git_dir_version }}}
-Release: 1%{?dist}
+Name:    @LONGNAME@
+Version: @VERSION@
+Release: @RELEASE@
 Summary: Message dispatch agent for cloud-connected systems
 License: GPLv3
 URL: https://github.com/redhatinsights/yggdrasil
 
-VCS: {{{ git_dir_vcs }}}
-Source: {{{ git_dir_pack }}}
+Source: %{name}-%{version}-%{release}.tar.gz
 
 ExclusiveArch: %{go_arches}
 
@@ -40,20 +28,20 @@ yggdrasil is pair of utilities that register systems with RHSM and establishes
 a receiving queue for instructions to be sent to the system via a broker.
 
 %prep
-{{{ git_dir_setup_macro }}}
+%autosetup -n %{name}-%{version}-%{release}
 
 
 %build
 make PREFIX=%{_prefix} \
      SYSCONFDIR=%{_sysconfdir} \
      LOCALSTATEDIR=%{_localstatedir} \
-     SHORTNAME=%{short_name} \
-     LONGNAME=%{long_name} \
-     PKGNAME=%{pkg_name} \
-     BRANDNAME=%{brand_name} \
-     TOPICPREFIX=%{topic_prefix} \
+     SHORTNAME=@SHORTNAME@ \
+     LONGNAME=@LONGNAME@ \
+     PKGNAME=@PKGNAME@ \
+     BRANDNAME=@BRANDNAME@ \
+     TOPICPREFIX=@TOPICPREFIX@ \
      VERSION=%{version} \
-     DATAHOST=%{data_host}
+     DATAHOST=@DATAHOST@
 
 
 %install
@@ -61,27 +49,26 @@ make PREFIX=%{_prefix} \
      SYSCONFDIR=%{_sysconfdir} \
      LOCALSTATEDIR=%{_localstatedir} \
      DESTDIR=%{buildroot} \
-     SHORTNAME=%{short_name} \
-     LONGNAME=%{long_name} \
-     PKGNAME=%{pkg_name} \
-     BRANDNAME=%{brand_name} \
-     TOPICPREFIX=%{topic_prefix} \
+     SHORTNAME=@SHORTNAME@ \
+     LONGNAME=@LONGNAME@ \
+     PKGNAME=@PKGNAME@ \
+     BRANDNAME=@BRANDNAME@ \
+     TOPICPREFIX=@TOPICPREFIX@ \
      VERSION=%{version} \
-     DATAHOST=%{data_host} \
+     DATAHOST=@DATAHOST@ \
      install
 
 
 %files
 %doc README.md
-%{_bindir}/%{short_name}
-%{_sbindir}/%{short_name}d
-%{_sysconfdir}/%{long_name}/config.toml
-%{_unitdir}/%{short_name}d.service
+%{_bindir}/@SHORTNAME@
+%{_sbindir}/@SHORTNAME@d
+%{_sysconfdir}/@LONGNAME@/config.toml
+%{_unitdir}/@SHORTNAME@d.service
 %{_datadir}/bash-completion/completions/*
 %{_mandir}/man1/*
-%{_prefix}/share/pkgconfig/%{long_name}.pc
-%{_libexecdir}/%{long_name}
+%{_prefix}/share/pkgconfig/@LONGNAME@.pc
+%{_libexecdir}/@LONGNAME@
 
 
 %changelog
-{{{ git_dir_changelog }}}


### PR DESCRIPTION
The `rpkg` build source type worked for a quick, initial integration with COPR to build RPMs. I want more control over how the version and release values get set during COPR builds, so this PR removes the `rpkg` template, and instead uses COPR's `make srpm` method of generating a source RPM.