### PR TITLE
feat(yggd): decouple MQTT client ID from certificate CN

### DIFF
--- a/cmd/yggd/main.go
+++ b/cmd/yggd/main.go
@@ -185,13 +185,17 @@ func main() {
 		ClientID = string(clientID)
 
 		// Read certificates, create a TLS config, and initialize HTTP client
-		certData, err := ioutil.ReadFile(c.String("cert-file"))
-		if err != nil {
-			return cli.Exit(fmt.Errorf("cannot read certificate file: %v", err), 1)
-		}
-		keyData, err := ioutil.ReadFile(c.String("key-file"))
-		if err != nil {
-			return cli.Exit(fmt.Errorf("cannot read key file: %w", err), 1)
+		var certData, keyData []byte
+		if c.String("cert-file") != "" && c.String("key-file") != "" {
+			var err error
+			certData, err = ioutil.ReadFile(c.String("cert-file"))
+			if err != nil {
+				return cli.Exit(fmt.Errorf("cannot read certificate file: %v", err), 1)
+			}
+			keyData, err = ioutil.ReadFile(c.String("key-file"))
+			if err != nil {
+				return cli.Exit(fmt.Errorf("cannot read key file: %w", err), 1)
+			}
 		}
 		rootCAs := make([][]byte, 0)
 		for _, file := range c.StringSlice("ca-root") {

--- a/cmd/yggd/tls.go
+++ b/cmd/yggd/tls.go
@@ -9,12 +9,14 @@ import (
 func newTLSConfig(certPEMBlock []byte, keyPEMBlock []byte, CARootPEMBlocks [][]byte) (*tls.Config, error) {
 	config := &tls.Config{}
 
-	cert, err := tls.X509KeyPair(certPEMBlock, keyPEMBlock)
-	if err != nil {
-		return nil, fmt.Errorf("cannot parse x509 key pair: %w", err)
-	}
+	if len(certPEMBlock) > 0 && len(keyPEMBlock) > 0 {
+		cert, err := tls.X509KeyPair(certPEMBlock, keyPEMBlock)
+		if err != nil {
+			return nil, fmt.Errorf("cannot parse x509 key pair: %w", err)
+		}
 
-	config.Certificates = []tls.Certificate{cert}
+		config.Certificates = []tls.Certificate{cert}
+	}
 
 	pool, err := x509.SystemCertPool()
 	if err != nil {

--- a/cmd/yggd/util.go
+++ b/cmd/yggd/util.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"math/rand"
+	"os"
 	"path/filepath"
 	"time"
 )
@@ -52,4 +53,52 @@ func parseCertCN(filename string) (string, error) {
 		return "", err
 	}
 	return cert.Subject.CommonName, nil
+}
+
+// createClientID will generate a semi-random string to be used as the MQTT
+// client ID and save the value to the client-id file.
+func createClientID(file string) ([]byte, error) {
+	if _, err := os.Stat(file); os.IsExist(err) {
+		return nil, fmt.Errorf("cannot create client-id: %w", err)
+	}
+
+	hostname, err := os.Hostname()
+	if err != nil {
+		return nil, fmt.Errorf("cannot get hostname: %w", err)
+	}
+
+	data := []byte(hostname + "-" + randomString(8))
+
+	if err := setClientID(data, file); err != nil {
+		return nil, fmt.Errorf("cannot set client-id: %w", err)
+	}
+
+	return data, nil
+}
+
+// setClientID writes data to the client ID file.
+func setClientID(data []byte, file string) error {
+	if err := os.MkdirAll(filepath.Dir(file), 0755); err != nil {
+		return fmt.Errorf("cannot create directory: %w", err)
+	}
+
+	if err := ioutil.WriteFile(file, data, 0600); err != nil {
+		return fmt.Errorf("cannot write file: %w", err)
+	}
+
+	return nil
+
+}
+
+// getClientID reads data from the client ID file.
+func getClientID(file string) ([]byte, error) {
+	if _, err := os.Stat(file); os.IsNotExist(err) {
+		return nil, nil
+	}
+	data, err := ioutil.ReadFile(file)
+	if err != nil {
+		return nil, fmt.Errorf("cannot read file: %w", err)
+	}
+
+	return data, nil
 }


### PR DESCRIPTION
There are 3 new functions that perform operations on a client ID file:

1. `createClientID` will generate a semi-random string and set the contents of the client-id file to that string.
2. `getClientID` simply reads the contents of the file.
3. `setClientID` writes a value it is given to the file.

These 3 functions are using during the main program execution to determine a client ID value. The logic is as follows:

If a "cert-file" option is given, the certificate is parsed for a CN value. That value is then written to the client-id file. The client-id file is then read. If the contents of the read file is empty, a client-id is generated via `createClientID`. The global `ClientID` variable is then set to the value either read from the client-id file or generated if the value was empty.

The HTTP and MQTT client is configured with a customized TLS configuration. If no cert/key pair is given, the TLS configuration is left without a certificate for authentication. This lets `yggd` run without requiring a certificate and still connect to brokers anonymously.