### PR TITLE
Conditionally configure certificate authentication

### DIFF
--- a/cmd/yggd/main.go
+++ b/cmd/yggd/main.go
@@ -165,13 +165,17 @@ func main() {
 		}
 
 		// Read certificates, create a TLS config, and initialize HTTP client
-		certData, err := ioutil.ReadFile(c.String("cert-file"))
-		if err != nil {
-			return cli.Exit(fmt.Errorf("cannot read certificate file: %v", err), 1)
-		}
-		keyData, err := ioutil.ReadFile(c.String("key-file"))
-		if err != nil {
-			return cli.Exit(fmt.Errorf("cannot read key file: %w", err), 1)
+		var certData, keyData []byte
+		if c.String("cert-file") != "" && c.String("key-file") != "" {
+			var err error
+			certData, err = ioutil.ReadFile(c.String("cert-file"))
+			if err != nil {
+				return cli.Exit(fmt.Errorf("cannot read certificate file: %v", err), 1)
+			}
+			keyData, err = ioutil.ReadFile(c.String("key-file"))
+			if err != nil {
+				return cli.Exit(fmt.Errorf("cannot read key file: %w", err), 1)
+			}
 		}
 		rootCAs := make([][]byte, 0)
 		for _, file := range c.StringSlice("ca-root") {

--- a/cmd/yggd/tls.go
+++ b/cmd/yggd/tls.go
@@ -9,12 +9,14 @@ import (
 func newTLSConfig(certPEMBlock []byte, keyPEMBlock []byte, CARootPEMBlocks [][]byte) (*tls.Config, error) {
 	config := &tls.Config{}
 
-	cert, err := tls.X509KeyPair(certPEMBlock, keyPEMBlock)
-	if err != nil {
-		return nil, fmt.Errorf("cannot parse x509 key pair: %w", err)
-	}
+	if len(certPEMBlock) > 0 && len(keyPEMBlock) > 0 {
+		cert, err := tls.X509KeyPair(certPEMBlock, keyPEMBlock)
+		if err != nil {
+			return nil, fmt.Errorf("cannot parse x509 key pair: %w", err)
+		}
 
-	config.Certificates = []tls.Certificate{cert}
+		config.Certificates = []tls.Certificate{cert}
+	}
 
 	pool, err := x509.SystemCertPool()
 	if err != nil {


### PR DESCRIPTION
Certificate authentication is only added to the TLS configuration if a cert/key pair are given. Otherwise, the HTTP requests will be unauthenticated. This is part of a larger effort to make certificates optional to the functionality of `yggd`.