### PR TITLE
fix: make malformed tags content not fatal

### DIFF
--- a/cmd/yggd/mqtt.go
+++ b/cmd/yggd/mqtt.go
@@ -92,17 +92,10 @@ func publishConnectionStatus(c mqtt.Client, dispatchers map[string]map[string]st
 
 	var tags map[string]string
 	if _, err := os.Stat(tagsFilePath); !os.IsNotExist(err) {
-		f, err := os.Open(tagsFilePath)
+		var err error
+		tags, err = readTagsFile(tagsFilePath)
 		if err != nil {
-			log.Errorf("cannot open '%v' for reading: %v", tagsFilePath, err)
-			return
-		}
-		defer f.Close()
-
-		tags, err = readTags(f)
-		if err != nil {
-			log.Errorf("cannot read tags file: %v", err)
-			return
+			log.Errorf("cannot load tags: %v", err)
 		}
 	}
 

--- a/cmd/yggd/tags.go
+++ b/cmd/yggd/tags.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"os"
 	"reflect"
 	"strconv"
 	"time"
@@ -56,5 +57,20 @@ func readTags(in io.Reader) (map[string]string, error) {
 		}
 	}
 
+	return tags, nil
+}
+
+// readTagsFile reads tag data from file.
+func readTagsFile(file string) (map[string]string, error) {
+	f, err := os.Open(file)
+	if err != nil {
+		return nil, fmt.Errorf("cannot open '%v' for reading: %w", file, err)
+	}
+	defer f.Close()
+
+	tags, err := readTags(f)
+	if err != nil {
+		return nil, fmt.Errorf("cannot read tags file: %w", err)
+	}
 	return tags, nil
 }


### PR DESCRIPTION
Change the tag parsing function to log an error, but continue to publish
the connection-status message with an empty tags map instead.

Fixes: ESSNTL-994
Fixes: ESSNTL-1128
Signed-off-by: Link Dupont <link@sub-pop.net>