### PR TITLE
Start workers explicitly

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,17 +69,26 @@ booleans, floats, Local Date, Local Time, Offset Date-Time and Local Date-Time).
 `yggd` has a dispatcher/worker protocol defined in `protocol/yggdrasil.proto`.
 This protocol defines two services (`Dispatcher` and `Worker`), along with the
 messages necessary for the services to exchange data. In order to interact with
-`yggd` as a worker process an executable must be installed into
-`$LIBEXECDIR/yggdrasil/`. The executable name must end with the string "worker".
+`yggd` as a worker process, a TOML configuration file must be installed into
+`$SYSCONFDIR/yggdrasil/workers`. The configuration file must contain a field
+called `exec` that's value is a valid path to an executable program. When `yggd`
+starts up its workers, the configuration file is used to locate and start the
+worker executable. Additional fields in the configuration file may be specified
+to further alter the behavior of the worker. The name of the worker's
+configuration file is assumed to be the handle value the worker claims during
+registration (i.e. a worker that would like to register with the "echo" handler
+value must be installed into the worker config directory under the name
+"echo.toml").
+
 A pkg-config module named 'yggdrasil' is installed so that workers can locate
-the worker exec directory at build time.
+the worker config directory at build time.
 
 ```
-pkg-config --variable workerexecdir yggdrasil
-/usr/local/libexec/yggdrasil
+pkg-config --variable workerconfdir yggdrasil
+/usr/local/etc/yggdrasil/workers
 ```
 
-A worker program must implement the `Worker` service.  `yggd` will execute
+A worker program must implement the `Worker` service. `yggd` will execute
 worker programs at start up. It will set the `YGG_SOCKET_ADDR` variable in the
 worker's environment. This address is the socket on which the worker must dial
 the dispatcher and call the "Register" RPC method. Upon successful registration,
@@ -87,3 +96,16 @@ the worker will receive back a socket address. The worker must bind to and
 listen on this address for RPC methods. See `worker/echo` for an example worker
 process that does nothing more than return the content data it received from the
 dispatcher.
+
+# Worker Configuration
+
+The following table includes valid fields for a worker configuration file:
+
+| **Field**  | **Value** | **Description** |
+| ---------- | --------- | --------------- |
+| `exec`     | `string`  | Path to an executable that is assumed to be the worker program (required). |
+| `protocol` | `string`  | RPC protocol the worker is using to communicate with`yggd`. Currently, only "grpc" is supported. |
+| `env`      | `array`   | Any additional values that a worker needs injected into its runtime enviroment before starting up. `PATH` and all variables beginning with `YGG_` are forbidden and may not be overridden. |
+
+An example of a worker configuration file can be see in the example `echo`
+worker directory: `./workers/echo/config.toml`.

--- a/cmd/yggd/client.go
+++ b/cmd/yggd/client.go
@@ -142,7 +142,7 @@ func (c *Client) DataReceiveHandlerFunc(data []byte, dest string) {
 func (c *Client) ReceiveData() {
 	for msg := range c.d.recvQ {
 		if err := c.SendDataMessage(&msg); err != nil {
-			log.Errorf("failed to send data message: %v", err)
+			log.Errorf("cannot send data message: %v", err)
 		}
 	}
 }

--- a/cmd/yggd/exec.go
+++ b/cmd/yggd/exec.go
@@ -82,10 +82,10 @@ func startProcess(file string, env []string, delay time.Duration, died chan int)
 		return
 	}
 
-	go watchProcess(cmd, delay, died)
+	go waitProcess(cmd, delay, died)
 }
 
-func watchProcess(cmd *exec.Cmd, delay time.Duration, died chan int) {
+func waitProcess(cmd *exec.Cmd, delay time.Duration, died chan int) {
 	log.Debugf("watching process: %v", cmd.Process.Pid)
 
 	state, err := cmd.Process.Wait()

--- a/cmd/yggd/exec.go
+++ b/cmd/yggd/exec.go
@@ -7,13 +7,10 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strconv"
-	"strings"
 	"time"
 
 	"git.sr.ht/~spc/go-log"
 	"github.com/redhatinsights/yggdrasil"
-	"github.com/rjeczalik/notify"
 )
 
 func startProcess(file string, env []string, delay time.Duration, died chan int) {
@@ -119,73 +116,4 @@ func killProcess(pid int) error {
 		log.Infof("killed process %v", process.Pid)
 	}
 	return nil
-}
-
-func killWorker(pidFile string) error {
-	data, err := ioutil.ReadFile(pidFile)
-	if err != nil {
-		return fmt.Errorf("cannot read contents of file: %w", err)
-	}
-	pid, err := strconv.ParseInt(string(data), 10, 64)
-	if err != nil {
-		return fmt.Errorf("cannot parse file contents as int: %w", err)
-	}
-
-	if err := killProcess(int(pid)); err != nil {
-		return fmt.Errorf("cannot kill process: %w", err)
-	}
-
-	if err := os.Remove(pidFile); err != nil {
-		return fmt.Errorf("cannot remove file: %w", err)
-	}
-	return nil
-}
-
-func killWorkers() error {
-	pidDirPath := filepath.Join(yggdrasil.LocalstateDir, "run", yggdrasil.LongName, "workers")
-	if err := os.MkdirAll(pidDirPath, 0755); err != nil {
-		return fmt.Errorf("cannot create directory: %w", err)
-	}
-	fileInfos, err := ioutil.ReadDir(pidDirPath)
-	if err != nil {
-		return fmt.Errorf("cannot read contents of directory: %w", err)
-	}
-
-	for _, info := range fileInfos {
-		pidFilePath := filepath.Join(pidDirPath, info.Name())
-		if err := killWorker(pidFilePath); err != nil {
-			return fmt.Errorf("cannot kill worker: %w", err)
-		}
-	}
-
-	return nil
-}
-
-func watchWorkerDir(dir string, env []string, died chan int) {
-	c := make(chan notify.EventInfo, 1)
-
-	if err := notify.Watch(dir, c, notify.InCloseWrite, notify.InDelete, notify.InMovedFrom, notify.InMovedTo); err != nil {
-		log.Errorf("cannot start notify watchpoint: %v", err)
-		return
-	}
-	defer notify.Stop(c)
-
-	for e := range c {
-		log.Debugf("received inotify event %v", e.Event())
-		switch e.Event() {
-		case notify.InCloseWrite, notify.InMovedTo:
-			if strings.HasSuffix(e.Path(), "worker") {
-				log.Tracef("new worker detected: %v", e.Path())
-				go startProcess(e.Path(), env, 0, died)
-			}
-		case notify.InDelete, notify.InMovedFrom:
-			workerName := filepath.Base(e.Path())
-			pidFilePath := filepath.Join(yggdrasil.LocalstateDir, "run", yggdrasil.LongName, "workers", workerName+".pid")
-
-			if err := killWorker(pidFilePath); err != nil {
-				log.Errorf("cannot kill worker: %v", err)
-				continue
-			}
-		}
-	}
 }

--- a/cmd/yggd/exec.go
+++ b/cmd/yggd/exec.go
@@ -12,7 +12,7 @@ import (
 // process has been started.
 func startProcess(file string, args []string, env []string, started func(pid int, stdout io.ReadCloser, stderr io.ReadCloser)) error {
 	if _, err := os.Stat(file); os.IsNotExist(err) {
-		return fmt.Errorf("cannot find file: %v", err)
+		return fmt.Errorf("cannot find file: %w", err)
 	}
 
 	cmd := exec.Command(file, args...)
@@ -20,16 +20,16 @@ func startProcess(file string, args []string, env []string, started func(pid int
 
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
-		return fmt.Errorf("cannot connect to stdout: %v", err)
+		return fmt.Errorf("cannot connect to stdout: %w", err)
 	}
 
 	stderr, err := cmd.StderrPipe()
 	if err != nil {
-		return fmt.Errorf("cannot connect to stderr: %v", err)
+		return fmt.Errorf("cannot connect to stderr: %w", err)
 	}
 
 	if err := cmd.Start(); err != nil {
-		return fmt.Errorf("cannot start process: %v: %v", file, err)
+		return fmt.Errorf("cannot start process: %v: %w", file, err)
 	}
 
 	if started != nil {
@@ -44,12 +44,12 @@ func startProcess(file string, args []string, env []string, started func(pid int
 func waitProcess(pid int, died func(pid int, state *os.ProcessState)) error {
 	process, err := os.FindProcess(pid)
 	if err != nil {
-		return fmt.Errorf("cannot find process with pid: %v", err)
+		return fmt.Errorf("cannot find process with pid %v: %w", pid, err)
 	}
 
 	state, err := process.Wait()
 	if err != nil {
-		return fmt.Errorf("process %v exited with error: %v", process.Pid, err)
+		return fmt.Errorf("process %v exited with error: %w", process.Pid, err)
 	}
 
 	if died != nil {
@@ -63,11 +63,11 @@ func waitProcess(pid int, died func(pid int, state *os.ProcessState)) error {
 func stopProcess(pid int) error {
 	process, err := os.FindProcess(pid)
 	if err != nil {
-		return fmt.Errorf("cannot find process with pid: %v", err)
+		return fmt.Errorf("cannot find process with pid %v: %w", pid, err)
 	}
 
 	if err := process.Kill(); err != nil {
-		return fmt.Errorf("cannot stop process: %v", err)
+		return fmt.Errorf("cannot stop process: %w", err)
 	}
 
 	return nil

--- a/cmd/yggd/exec_test.go
+++ b/cmd/yggd/exec_test.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"io"
+	"testing"
+)
+
+func TestStartProcess(t *testing.T) {
+	tests := []struct {
+		description string
+		input       struct {
+			file string
+			args []string
+			env  []string
+		}
+	}{
+		{
+			input: struct {
+				file string
+				args []string
+				env  []string
+			}{
+				file: "/usr/bin/sleep",
+				args: []string{"1"},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			err := startProcess(test.input.file, test.input.args, test.input.env, nil)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestStopProcess(t *testing.T) {
+	tests := []struct {
+		description string
+		input       struct {
+			file string
+			args []string
+			env  []string
+		}
+	}{
+		{
+			input: struct {
+				file string
+				args []string
+				env  []string
+			}{
+				file: "/usr/bin/sleep",
+				args: []string{"3"},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			err := startProcess(test.input.file, test.input.args, test.input.env, func(pid int, stdout, stderr io.ReadCloser) {
+				if err := stopProcess(pid); err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+			})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestWaitProcess(t *testing.T) {
+	tests := []struct {
+		description string
+		input       struct {
+			file string
+			args []string
+			env  []string
+		}
+	}{
+		{
+			input: struct {
+				file string
+				args []string
+				env  []string
+			}{
+				file: "/usr/bin/sleep",
+				args: []string{"3"},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+
+			err := startProcess(test.input.file, test.input.args, test.input.env, func(pid int, stdout, stderr io.ReadCloser) {
+				if err := waitProcess(pid, nil); err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+			})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}

--- a/cmd/yggd/grpc.go
+++ b/cmd/yggd/grpc.go
@@ -137,7 +137,7 @@ func (d *dispatcher) disconnectWorker(w *worker) error {
 
 	_, err = workerClient.NotifyEvent(ctx, &pb.EventNotification{Name: pb.Event_RECEIVED_DISCONNECT})
 	if err != nil {
-		log.Errorf("cannot disconnect worker %v", err)
+		log.Errorf("cannot disconnect worker %v: %v", w, err)
 		return err
 	}
 	return nil
@@ -150,7 +150,7 @@ func (d *dispatcher) sendData() {
 			w := d.reg.get(data.Directive)
 
 			if w == nil {
-				log.Warnf("cannot route message to directive: %v", data.Directive)
+				log.Warnf("cannot route message  %v to directive: %v", data.MessageID, data.Directive)
 				return
 			}
 

--- a/cmd/yggd/main.go
+++ b/cmd/yggd/main.go
@@ -307,6 +307,7 @@ func main() {
 					msg, err := client.ConnectionStatus()
 					if err != nil {
 						log.Errorf("cannot get connection status: %v", err)
+						return
 					}
 					if err = client.SendConnectionStatusMessage(msg); err != nil {
 						log.Errorf("cannot send connection status: %v", err)

--- a/cmd/yggd/registry.go
+++ b/cmd/yggd/registry.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"sync"
+)
+
+var errWorkerRegistered = registryError("cannot add worker; a worker is already registered")
+
+type registryError string
+
+func (e registryError) Error() string { return string(e) }
+
+type registry struct {
+	mu sync.RWMutex
+	mp map[string]*worker
+}
+
+func (r *registry) init() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if r.mp == nil {
+		r.mp = make(map[string]*worker)
+	}
+}
+
+func (r *registry) set(handler string, w *worker) error {
+	r.init()
+
+	if r.get(handler) != nil {
+		return errWorkerRegistered
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.mp[handler] = w
+
+	return nil
+}
+
+func (r *registry) get(handler string) *worker {
+	r.init()
+
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	return r.mp[handler]
+}
+
+func (r *registry) del(handler string) {
+	r.init()
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	delete(r.mp, handler)
+}
+
+func (r *registry) all() map[string]*worker {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	all := make(map[string]*worker)
+	for k, w := range r.mp {
+		all[k] = w
+	}
+
+	return all
+}

--- a/cmd/yggd/registry_test.go
+++ b/cmd/yggd/registry_test.go
@@ -1,0 +1,237 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+)
+
+func TestSet(t *testing.T) {
+	tests := []struct {
+		description string
+		input       []struct {
+			handler string
+			worker  *worker
+		}
+		want      *registry
+		wantError error
+	}{
+		{
+			description: "two handler values",
+			input: []struct {
+				handler string
+				worker  *worker
+			}{
+				{
+					handler: "test1",
+					worker: &worker{
+						handler: "test1",
+					},
+				},
+				{
+					handler: "test2",
+					worker: &worker{
+						handler: "test2",
+					},
+				},
+			},
+			want: &registry{
+				mp: map[string]*worker{
+					"test1": {
+						handler: "test1",
+					},
+					"test2": {
+						handler: "test2",
+					},
+				},
+			},
+		},
+		{
+			description: "duplicate handler value",
+			input: []struct {
+				handler string
+				worker  *worker
+			}{
+				{
+					handler: "test",
+					worker: &worker{
+						handler: "test",
+					},
+				},
+				{
+					handler: "test",
+					worker: &worker{
+						handler: "test",
+					},
+				},
+			},
+			wantError: errWorkerRegistered,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			got := &registry{}
+
+			for _, input := range test.input {
+				if err := got.set(input.handler, input.worker); err != nil {
+					if err != nil {
+						if test.wantError != nil {
+							if !cmp.Equal(err, test.wantError) {
+								t.Fatalf("%#v != %#v", err, test.wantError)
+							}
+						} else {
+							t.Fatalf("unexpected error: %v", err)
+						}
+					}
+				}
+			}
+
+			if test.wantError == nil {
+				if !cmp.Equal(got, test.want, cmp.AllowUnexported(registry{}, worker{}), cmpopts.IgnoreFields(registry{}, "mu")) {
+					t.Fatalf("%#v != %#v", got, test.want)
+				}
+			}
+		})
+	}
+}
+
+func TestGet(t *testing.T) {
+	tests := []struct {
+		description string
+		input       struct {
+			r       *registry
+			handler string
+		}
+		want *worker
+	}{
+		{
+			description: "present",
+			input: struct {
+				r       *registry
+				handler string
+			}{
+				r: &registry{
+					mp: map[string]*worker{
+						"test": {
+							handler: "test",
+						},
+					},
+				},
+				handler: "test",
+			},
+			want: &worker{
+				handler: "test",
+			},
+		},
+		{
+			description: "absent",
+			input: struct {
+				r       *registry
+				handler string
+			}{
+				r: &registry{
+					mp: map[string]*worker{
+						"test": {
+							handler: "test",
+						},
+					},
+				},
+				handler: "test2",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			got := test.input.r.get(test.input.handler)
+
+			if !cmp.Equal(got, test.want, cmp.AllowUnexported(registry{}, worker{}), cmpopts.IgnoreFields(registry{}, "mu")) {
+				t.Errorf("%#v != %#v", got, test.want)
+			}
+		})
+	}
+}
+
+func TestDel(t *testing.T) {
+	tests := []struct {
+		description string
+		input       struct {
+			r *registry
+			h string
+		}
+		want *registry
+	}{
+		{
+			input: struct {
+				r *registry
+				h string
+			}{
+				r: &registry{
+					mp: map[string]*worker{
+						"test": {
+							handler: "test",
+						},
+					},
+				},
+				h: "test",
+			},
+			want: &registry{
+				mp: map[string]*worker{},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			got := &registry{
+				mp: test.input.r.mp,
+			}
+			got.del(test.input.h)
+
+			if !cmp.Equal(got, test.want, cmp.AllowUnexported(registry{}, worker{}), cmpopts.IgnoreFields(registry{}, "mu")) {
+				t.Errorf("%#v != %#v", got, test.want)
+			}
+		})
+	}
+}
+
+func TestAll(t *testing.T) {
+	tests := []struct {
+		description string
+		input       *registry
+		want        map[string]*worker
+	}{
+		{
+			input: &registry{
+				mp: map[string]*worker{
+					"test1": {
+						handler: "test1",
+					},
+					"test2": {
+						handler: "test2",
+					},
+				},
+			},
+			want: map[string]*worker{
+				"test1": {
+					handler: "test1",
+				},
+				"test2": {
+					handler: "test2",
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			got := test.input.all()
+
+			if !cmp.Equal(got, test.want, cmp.AllowUnexported(registry{}, worker{}), cmpopts.IgnoreFields(registry{}, "mu")) {
+				t.Errorf("%#v != %#v", got, test.want)
+			}
+		})
+	}
+}

--- a/cmd/yggd/worker.go
+++ b/cmd/yggd/worker.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"git.sr.ht/~spc/go-log"
+	"github.com/redhatinsights/yggdrasil"
+	"github.com/rjeczalik/notify"
+)
+
+func killWorker(pidFile string) error {
+	data, err := ioutil.ReadFile(pidFile)
+	if err != nil {
+		return fmt.Errorf("cannot read contents of file: %w", err)
+	}
+	pid, err := strconv.ParseInt(string(data), 10, 64)
+	if err != nil {
+		return fmt.Errorf("cannot parse file contents as int: %w", err)
+	}
+
+	if err := killProcess(int(pid)); err != nil {
+		return fmt.Errorf("cannot kill process: %w", err)
+	}
+
+	if err := os.Remove(pidFile); err != nil {
+		return fmt.Errorf("cannot remove file: %w", err)
+	}
+	return nil
+}
+
+func killWorkers() error {
+	pidDirPath := filepath.Join(yggdrasil.LocalstateDir, "run", yggdrasil.LongName, "workers")
+	if err := os.MkdirAll(pidDirPath, 0755); err != nil {
+		return fmt.Errorf("cannot create directory: %w", err)
+	}
+	fileInfos, err := ioutil.ReadDir(pidDirPath)
+	if err != nil {
+		return fmt.Errorf("cannot read contents of directory: %w", err)
+	}
+
+	for _, info := range fileInfos {
+		pidFilePath := filepath.Join(pidDirPath, info.Name())
+		if err := killWorker(pidFilePath); err != nil {
+			return fmt.Errorf("cannot kill worker: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func watchWorkerDir(dir string, env []string, died chan int) {
+	c := make(chan notify.EventInfo, 1)
+
+	if err := notify.Watch(dir, c, notify.InCloseWrite, notify.InDelete, notify.InMovedFrom, notify.InMovedTo); err != nil {
+		log.Errorf("cannot start notify watchpoint: %v", err)
+		return
+	}
+	defer notify.Stop(c)
+
+	for e := range c {
+		log.Debugf("received inotify event %v", e.Event())
+		switch e.Event() {
+		case notify.InCloseWrite, notify.InMovedTo:
+			if strings.HasSuffix(e.Path(), "worker") {
+				log.Tracef("new worker detected: %v", e.Path())
+				go startProcess(e.Path(), env, 0, died)
+			}
+		case notify.InDelete, notify.InMovedFrom:
+			workerName := filepath.Base(e.Path())
+			pidFilePath := filepath.Join(yggdrasil.LocalstateDir, "run", yggdrasil.LongName, "workers", workerName+".pid")
+
+			if err := killWorker(pidFilePath); err != nil {
+				log.Errorf("cannot kill worker: %v", err)
+				continue
+			}
+		}
+	}
+}

--- a/cmd/yggd/worker.go
+++ b/cmd/yggd/worker.go
@@ -230,6 +230,11 @@ func watchWorkerDir(dir string, died chan int) {
 			if err != nil {
 				log.Errorf("cannot load worker config: %v", err)
 			}
+			if ExcludeWorkers[config.directive] {
+				log.Tracef("skipping excluded worker %v", config.directive)
+				continue
+			}
+			log.Debugf("starting worker: %v", config.directive)
 			go func() {
 				if err := startWorker(*config, nil, func(pid int) {
 					died <- pid

--- a/cmd/yggd/worker.go
+++ b/cmd/yggd/worker.go
@@ -239,7 +239,7 @@ func watchWorkerDir(dir string, died chan int) {
 				if err := startWorker(*config, nil, func(pid int) {
 					died <- pid
 				}); err != nil {
-					log.Errorf("cannot start worker: %v", err)
+					log.Errorf("cannot start worker %v: %v", config.directive, err)
 					return
 				}
 			}()
@@ -247,7 +247,7 @@ func watchWorkerDir(dir string, died chan int) {
 			name := strings.TrimSuffix(filepath.Base(e.Path()), filepath.Ext(e.Path()))
 
 			if err := stopWorker(name); err != nil {
-				log.Errorf("cannot kill worker: %v", err)
+				log.Errorf("cannot kill worker %v: %v", name, err)
 				continue
 			}
 		}

--- a/cmd/yggd/worker.go
+++ b/cmd/yggd/worker.go
@@ -1,23 +1,34 @@
 package main
 
 import (
+	"bufio"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strconv"
 	"strings"
+	"time"
 
 	"git.sr.ht/~spc/go-log"
 	"github.com/pelletier/go-toml"
 	"github.com/redhatinsights/yggdrasil"
 	"github.com/rjeczalik/notify"
+	"golang.org/x/net/http/httpproxy"
 )
 
 type workerConfig struct {
-	Exec string `toml:"exec"`
+	Exec      string   `toml:"exec"`
+	Protocol  string   `toml:"protocol"`
+	Env       []string `toml:"env"`
+	delay     time.Duration
+	directive string
 }
 
+// loadWorkerConfig reads the contents of file and parses it into a workerConfig
+// value.
 func loadWorkerConfig(file string) (*workerConfig, error) {
 	data, err := ioutil.ReadFile(file)
 	if err != nil {
@@ -28,51 +39,180 @@ func loadWorkerConfig(file string) (*workerConfig, error) {
 	if err := toml.Unmarshal(data, &config); err != nil {
 		return nil, fmt.Errorf("cannot load config: %w", err)
 	}
+	config.directive = strings.TrimSuffix(filepath.Base(file), filepath.Ext(file))
 
 	return &config, nil
 }
 
-func killWorker(pidFile string) error {
+// startWorker constructs a command to execute from the given workerConfig,
+// starts it, and starts a goroutine that waits for the process to exit. If not
+// nil, started is invoked after the process is started. Likewise, when the
+// process is stopped, stopped is invoked.
+func startWorker(config workerConfig, started func(pid int), stopped func(pid int)) error {
+	argv := strings.Split(config.Exec, " ")
+
+	program := argv[0]
+	var args []string
+	if len(argv) > 1 {
+		args = argv[1:]
+	}
+
+	env := []string{
+		"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+		"YGG_CONFIG_DIR=" + filepath.Join(yggdrasil.SysconfDir, yggdrasil.LongName),
+		"YGG_LOG_LEVEL=" + log.CurrentLevel().String(),
+		"YGG_CLIENT_ID=" + ClientID,
+	}
+
+	proxy := httpproxy.FromEnvironment()
+	if proxy.HTTPProxy != "" {
+		env = append(env, "HTTP_PROXY="+proxy.HTTPProxy)
+	}
+	if proxy.HTTPSProxy != "" {
+		env = append(env, "HTTPS_PROXY="+proxy.HTTPSProxy)
+	}
+	if proxy.NoProxy != "" {
+		env = append(env, "NO_PROXY="+proxy.NoProxy)
+	}
+
+	switch config.Protocol {
+	case "grpc":
+		env = append(env, "YGG_SOCKET_ADDR=unix:"+SocketAddr)
+	default:
+		return fmt.Errorf("unsupported protocol: %v", config.Protocol)
+	}
+
+	for _, val := range config.Env {
+		if validEnvVar(val) {
+			env = append(env, val)
+		}
+	}
+
+	if config.delay < 0 {
+		return fmt.Errorf("failed to start worker %v too many times", program)
+	}
+
+	if config.delay > 0 {
+		log.Tracef("delaying worker start for %v...", config.delay)
+		time.Sleep(config.delay)
+	}
+
+	err := startProcess(program, args, env, func(pid int, stdout, stderr io.ReadCloser) {
+		go func() {
+			scanner := bufio.NewScanner(stdout)
+			for scanner.Scan() {
+				log.Debugf("%v: %v", program, scanner.Text())
+			}
+			if err := scanner.Err(); err != nil {
+				log.Errorf("cannot read from stdout: %v", err)
+			}
+		}()
+
+		go func() {
+			scanner := bufio.NewScanner(stderr)
+			for scanner.Scan() {
+				log.Warnf("%v: %v", program, scanner.Text())
+			}
+			if err := scanner.Err(); err != nil {
+				log.Errorf("cannot read from stderr: %v", err)
+			}
+		}()
+
+		pidDirPath := filepath.Join(yggdrasil.LocalstateDir, "run", yggdrasil.LongName, "workers")
+
+		if err := os.MkdirAll(pidDirPath, 0755); err != nil {
+			log.Errorf("cannot create directory: %v", err)
+			return
+		}
+
+		if err := ioutil.WriteFile(filepath.Join(pidDirPath, config.directive+".pid"), []byte(fmt.Sprintf("%v", pid)), 0644); err != nil {
+			log.Errorf("cannot write to file: %v", err)
+			return
+		}
+
+		if started != nil {
+			go started(pid)
+		}
+
+		if err := waitProcess(pid, func(pid int, state *os.ProcessState) {
+			log.Infof("worker stopped: %v", pid)
+
+			if state.SystemTime() < time.Duration(1*time.Second) {
+				config.delay += 5 * time.Second
+			}
+
+			if config.delay >= time.Duration(30*time.Second) {
+				config.delay = -1
+			}
+
+			if stopped != nil {
+				go stopped(pid)
+			}
+
+			if workerExists(config.directive) {
+				if err := startWorker(config, started, stopped); err != nil {
+					log.Errorf("cannot restart worker: %v", err)
+					return
+				}
+			}
+		}); err != nil {
+			log.Errorf("process exited with an error: %v", err)
+		}
+	})
+
+	if err != nil {
+		return fmt.Errorf("cannot start worker: %w", err)
+	}
+
+	return nil
+}
+
+// stopWorker looks for a PID file with the given name, parses it as a integer,
+// assumes it is a process PID and stops the process.
+func stopWorker(name string) error {
+	pidFile := filepath.Join(yggdrasil.LocalstateDir, "run", yggdrasil.LongName, "workers", name+".pid")
+
 	data, err := ioutil.ReadFile(pidFile)
 	if err != nil {
-		return fmt.Errorf("cannot read contents of file: %w", err)
+		return fmt.Errorf("cannot read file: %w", err)
 	}
-	pid, err := strconv.ParseInt(string(data), 10, 64)
+	pid, err := strconv.ParseInt(strings.TrimSpace(string(data)), 10, 64)
 	if err != nil {
-		return fmt.Errorf("cannot parse file contents as int: %w", err)
+		return fmt.Errorf("cannot parse data: %w", err)
 	}
-
-	if err := killProcess(int(pid)); err != nil {
-		return fmt.Errorf("cannot kill process: %w", err)
+	if err := stopProcess(int(pid)); err != nil {
+		return fmt.Errorf("cannot stop worker: %w", err)
 	}
-
 	if err := os.Remove(pidFile); err != nil {
 		return fmt.Errorf("cannot remove file: %w", err)
 	}
 	return nil
 }
 
-func killWorkers() error {
-	pidDirPath := filepath.Join(yggdrasil.LocalstateDir, "run", yggdrasil.LongName, "workers")
-	if err := os.MkdirAll(pidDirPath, 0755); err != nil {
+// stopWorkers reads all pid files from the local state directory and attempts
+// to stop the worker process.
+func stopWorkers() error {
+	dir := filepath.Join(yggdrasil.LocalstateDir, "run", yggdrasil.LongName, "workers")
+	if err := os.MkdirAll(dir, 0755); err != nil {
 		return fmt.Errorf("cannot create directory: %w", err)
 	}
-	fileInfos, err := ioutil.ReadDir(pidDirPath)
+	infos, err := ioutil.ReadDir(dir)
 	if err != nil {
 		return fmt.Errorf("cannot read contents of directory: %w", err)
 	}
 
-	for _, info := range fileInfos {
-		pidFilePath := filepath.Join(pidDirPath, info.Name())
-		if err := killWorker(pidFilePath); err != nil {
-			return fmt.Errorf("cannot kill worker: %w", err)
+	for _, info := range infos {
+		if strings.HasSuffix(info.Name(), ".pid") {
+			if err := stopWorker(strings.TrimSuffix(info.Name(), ".pid")); err != nil {
+				return fmt.Errorf("cannot stop worker: %w", err)
+			}
 		}
 	}
 
 	return nil
 }
 
-func watchWorkerDir(dir string, env []string, died chan int) {
+func watchWorkerDir(dir string, died chan int) {
 	c := make(chan notify.EventInfo, 1)
 
 	if err := notify.Watch(dir, c, notify.InCloseWrite, notify.InDelete, notify.InMovedFrom, notify.InMovedTo); err != nil {
@@ -85,27 +225,42 @@ func watchWorkerDir(dir string, env []string, died chan int) {
 		log.Debugf("received inotify event %v", e.Event())
 		switch e.Event() {
 		case notify.InCloseWrite, notify.InMovedTo:
-			if strings.HasSuffix(e.Path(), "worker") {
-				log.Tracef("new worker detected: %v", e.Path())
-				config, err := loadWorkerConfig(e.Path())
-				if err != nil {
-					log.Errorf("cannot load worker config: %v", err)
-				}
-				go startProcess(config.Exec, env, 0, died)
-			}
-		case notify.InDelete, notify.InMovedFrom:
+			log.Tracef("new worker detected: %v", e.Path())
 			config, err := loadWorkerConfig(e.Path())
 			if err != nil {
 				log.Errorf("cannot load worker config: %v", err)
-				continue
 			}
-			workerName := filepath.Base(config.Exec)
-			pidFilePath := filepath.Join(yggdrasil.LocalstateDir, "run", yggdrasil.LongName, "workers", workerName+".pid")
+			go func() {
+				if err := startWorker(*config, nil, func(pid int) {
+					died <- pid
+				}); err != nil {
+					log.Errorf("cannot start worker: %v", err)
+					return
+				}
+			}()
+		case notify.InDelete, notify.InMovedFrom:
+			name := strings.TrimSuffix(filepath.Base(e.Path()), filepath.Ext(e.Path()))
 
-			if err := killWorker(pidFilePath); err != nil {
+			if err := stopWorker(name); err != nil {
 				log.Errorf("cannot kill worker: %v", err)
 				continue
 			}
 		}
 	}
+}
+
+func workerExists(name string) bool {
+	_, err := os.Stat(filepath.Join(yggdrasil.SysconfDir, yggdrasil.LongName, "workers", name+".toml"))
+	return !os.IsNotExist(err)
+}
+
+func validEnvVar(val string) bool {
+	for _, pattern := range []string{"PATH=.*", "YGG_.*=.*"} {
+		r := regexp.MustCompile(pattern)
+		if r.Match([]byte(val)) {
+			return false
+		}
+	}
+
+	return true
 }

--- a/cmd/yggd/worker_test.go
+++ b/cmd/yggd/worker_test.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+)
+
+func TestValidEnvVar(t *testing.T) {
+	tests := []struct {
+		description string
+		input       string
+		want        bool
+	}{
+		{
+			description: "invalid: PATH",
+			input:       "PATH=/opt/bin:$PATH",
+			want:        false,
+		},
+		{
+			description: "valid: HTTP_PROXY",
+			input:       "HTTP_PROXY=http://localhost:8080",
+			want:        true,
+		},
+		{
+			description: "invalid: YGG_SOCKET_ADDR",
+			input:       "YGG_SOCKET_ADDR=@yggd",
+			want:        false,
+		},
+		{
+			description: "valid: YGGD_VERSION",
+			input:       "YGGD_VERSION=1.2.3",
+			want:        true,
+		},
+		{
+			description: "invalid: YGG_VERSION",
+			input:       "YGG_VERSION=1.2.3",
+			want:        false,
+		},
+		{
+			description: "invalid: YGG_=",
+			input:       "YGG_=",
+			want:        false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			got := validEnvVar(test.input)
+
+			if !cmp.Equal(got, test.want) {
+				t.Errorf("%#v != %#v", got, test.want)
+			}
+		})
+	}
+}
+
+func TestStartWorker(t *testing.T) {
+	tests := []struct {
+		description string
+		input       workerConfig
+		want        string
+		wantError   error
+	}{
+		{
+			input: workerConfig{
+				Exec:      "/usr/bin/echo test",
+				Protocol:  "grpc",
+				Env:       []string{},
+				delay:     0,
+				directive: "echo-test",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			err := startWorker(test.input, nil, nil)
+
+			if test.wantError != nil {
+				if !cmp.Equal(err, test.wantError, cmpopts.EquateErrors()) {
+					t.Errorf("%#v != %#v", err, test.wantError)
+				}
+			} else {
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/pelletier/go-toml v1.9.3
 	github.com/rjeczalik/notify v0.9.2
 	github.com/urfave/cli/v2 v2.3.0
-	golang.org/x/net v0.0.0-20201031054903-ff519b6c9102 // indirect
+	golang.org/x/net v0.0.0-20201031054903-ff519b6c9102
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 	google.golang.org/grpc v1.34.0
 	google.golang.org/protobuf v1.25.0

--- a/worker/echo/echo.toml
+++ b/worker/echo/echo.toml
@@ -1,1 +1,3 @@
 exec = "/usr/local/libexec/yggdrasil/ygg-echo-worker"
+protocol = "grpc"
+env = []

--- a/worker/echo/echo.toml
+++ b/worker/echo/echo.toml
@@ -1,0 +1,1 @@
+exec = "/usr/local/libexec/yggdrasil/ygg-echo-worker"


### PR DESCRIPTION
This PR refactors the way processes are started, watched, killed, and restarted. The routines in `exec.go` were a mixture of higher-level worker process management (including restart delays, PID file management, etc.) and lower-level process start and kill routines. This PR moves the higher-level logic out of `exec.go` and into a file called `worker.go`. The routines in `exec.go` are now purely lower-level routines that start and stop processes; they have no awareness of worker configuration or process restart management (`startProcess`, `stopProcess`, `waitProcess`). The functions in `worker.go` operate on a `workerConfig` data structure to start, stop and manage workers.

A `workerConfig` structure is created by parsing a configuration file that must be defined in `/etc/yggdrasil/workers`. The existence of this file determines whether `yggd` is aware of, and will manage, a worker (previously this was handled by the existence of an executable program in `/usr/libexec/yggdrasil`). While a binary may still exist there, it will not be automatically started unless a valid configuration file points to that file as its executable. The name of the configuration file, minus the `.toml` suffix, is assumed to be the worker's handle (this ensures that no two workers will attempt to claim the same handle value).

For example, the echo worker now includes a configuration file:

```toml
exec="/usr/local/libexec/ygg-echo-worker"
protocol="grpc"
env=[]
```

The `exec` field must be a valid executable program. The `protocol` field is used to define which RPC protocol the worker is using. Currently the only supported value is "grpc". Values in the `env` array must be strings in the form of "VAR=VALUE" and are inserted into a worker's environment before starting it. Any value in the array that begins with either "PATH" or "YGG_" is ignored (in other words, a worker *may not* override its own `PATH` or any variable beginning with `YGG_` environment variables through its configuration file).

A worker's environment is automatically configured with a reasonable base PATH value (`/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin`) and inherits values from its parent for: `http_proxy`, `HTTP_PROXY`, `HTTPS_PROXY`, `ALL_PROXY`, and `NO_PROXY`.

A worker can be excluded from activation either permanently (by adding a value to the configuration file) or temporarily (by using the `--exclude-worker` command line flag). If a worker's name is found in this list during worker startup, it is skipped. It will not be started by `yggd` until the name is removed from the configuration value and `yggd` is restarted.

Little functionality should be changed by this PR. It mainly lays some groundwork to enable more functionality down the road. Nonetheless, this is a breaking change for workers, so it will not ship without advanced notice.

Fixes: ESSNTL-302, ESSNTL-298, ESSNTL-279