### PR TITLE
ci: Add Github Workflow Actions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,32 @@
+name: Go
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    name: "Build"
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go: ['1.15', '1.16', '1.17']
+    steps:
+      - name: Updating ...
+        run: sudo apt-get -qq update
+
+      - uses: actions/checkout@v2
+
+      - name: Setup go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ matrix.go }}
+
+      - name: Go build (source)
+        run: make
+
+      - name: Go build (tests)
+        run: make tests
+
+      - name: Go vet
+        run: make vet

--- a/Makefile
+++ b/Makefile
@@ -163,3 +163,11 @@ clean:
 	go mod tidy
 	rm $(BINS)
 	rm $(DATA)
+
+.PHONY: tests
+tests:
+	go test -v ./...
+
+.PHONY: vet
+vet:
+	go vet -v ./...


### PR DESCRIPTION
This patch adds multiple GitHub Workflow Actions:

* Run go build, go test and go vet

Signed-off-by: Gael Chamoulaud (Strider) <gchamoul@redhat.com>