### PR TITLE
Using UUID for generated ClientID

### DIFF
--- a/cmd/yggd/util.go
+++ b/cmd/yggd/util.go
@@ -4,6 +4,7 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
+	"github.com/google/uuid"
 	"io/ioutil"
 	"math/rand"
 	"os"
@@ -67,7 +68,12 @@ func createClientID(file string) ([]byte, error) {
 		return nil, fmt.Errorf("cannot get hostname: %w", err)
 	}
 
-	data := []byte(hostname + "-" + randomString(8))
+	generatedUUID, err := uuid.NewUUID()
+	if err != nil {
+		return nil, fmt.Errorf("cannot generate UUID: %w", err)
+	}
+
+	data := []byte(hostname + "-" + generatedUUID.String())
 
 	if err := setClientID(data, file); err != nil {
 		return nil, fmt.Errorf("cannot set client-id: %w", err)


### PR DESCRIPTION
k4e needs the generated client ID to be a valid kubernetes name and capital letters that might appear in the suffix generated by `randomString(8)` are not allowed. 

Proposed fix uses UUID as a suffix, which should provide both better entropy and compliance with k8s naming requirements.