### PR TITLE
Additional environment variables

### DIFF
--- a/cmd/yggd/main.go
+++ b/cmd/yggd/main.go
@@ -343,9 +343,9 @@ func main() {
 		env := []string{
 			"YGG_SOCKET_ADDR=unix:" + c.String("socket-addr"),
 			"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
-			"BASE_CONFIG_DIR=" + configDir,
-			"LOG_LEVEL=" + level.String(),
-			"DEVICE_ID=" + ClientID,
+			"YGG_CONFIG_DIR=" + configDir,
+			"YGG_LOG_LEVEL=" + level.String(),
+			"YGG_CLIENT_ID=" + ClientID,
 		}
 		for _, info := range fileInfos {
 			if strings.HasSuffix(info.Name(), "worker") {

--- a/cmd/yggd/main.go
+++ b/cmd/yggd/main.go
@@ -345,6 +345,7 @@ func main() {
 			"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
 			"BASE_CONFIG_DIR=" + configDir,
 			"LOG_LEVEL=" + level.String(),
+			"DEVICE_ID=" + ClientID,
 		}
 		for _, info := range fileInfos {
 			if strings.HasSuffix(info.Name(), "worker") {

--- a/cmd/yggd/main.go
+++ b/cmd/yggd/main.go
@@ -339,10 +339,12 @@ func main() {
 		if err != nil {
 			return cli.Exit(fmt.Errorf("cannot read contents of directory: %w", err), 1)
 		}
-
+		configDir := filepath.Join(yggdrasil.SysconfDir, yggdrasil.LongName)
 		env := []string{
 			"YGG_SOCKET_ADDR=unix:" + c.String("socket-addr"),
 			"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+			"BASE_CONFIG_DIR=" + configDir,
+			"LOG_LEVEL=" + level.String(),
 		}
 		for _, info := range fileInfos {
 			if strings.HasSuffix(info.Name(), "worker") {


### PR DESCRIPTION
This PR adds couple of environment variables that are passed to the workers:
 - `BASE_CONFIG_DIR` - yggdrasil configuration directory, within which the workers can create their own configuration subdirectory;
 - `LOG_LEVEL` - forwarding yggdrasil's log level to be applied by the workers;
 - `DEVICE_ID` - ID of the device as used by yggdrasil; to give workers possibility to use device identity in their logic.