### PR TITLE
Support for building aarch64 version

### DIFF
--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -2,6 +2,8 @@ include Makefile
 
 SOURCEDIR := $(shell rpmbuild -E %_sourcedir)
 SRCRPMDIR := $(shell rpmbuild -E %_srcrpmdir)
+$(shell mkdir -p $(SOURCEDIR))
+$(shell mkdir -p $(SRCRPMDIR))
 
 srpm: SHORTNAME = $(shell basename $(PWD))
 srpm: LONGNAME = $(SHORTNAME)

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@
 /yggd.bash
 /yggdrasil.spec
 /doc/tags.toml
+
+*.gz

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ VERSION   := 0.2.98
 # Used as the prefix for MQTT topic names
 TOPICPREFIX := yggdrasil
 # Used to force sending all HTTP traffic to a specific host.
-DATAHOST := 
+DATAHOST :=
 # Used to identify the agency providing the connection broker.
 PROVIDER :=
 
@@ -42,7 +42,7 @@ DESTDIR       ?=
 SYSTEMD_SYSTEM_UNIT_DIR  := $(shell pkg-config --variable systemdsystemunitdir systemd)
 
 # Build flags
-LDFLAGS := 
+LDFLAGS :=
 LDFLAGS += -X 'github.com/redhatinsights/yggdrasil.Version=$(VERSION)'
 LDFLAGS += -X 'github.com/redhatinsights/yggdrasil.ShortName=$(SHORTNAME)'
 LDFLAGS += -X 'github.com/redhatinsights/yggdrasil.LongName=$(LONGNAME)'
@@ -65,6 +65,11 @@ BUILDFLAGS ?=
 BUILDFLAGS += -buildmode=pie
 ifeq ($(shell find . -name vendor), ./vendor)
 BUILDFLAGS += -mod=vendor
+endif
+
+ARCH ?= x86_64
+ifeq ($(ARCH),aarch64)
+	export GOARCH=arm64
 endif
 
 BINS = yggd

--- a/yggdrasil.spec.in
+++ b/yggdrasil.spec.in
@@ -32,6 +32,7 @@ a receiving queue for instructions to be sent to the system via a broker.
 
 
 %build
+export CGO_ENABLED=0
 make PREFIX=%{_prefix} \
      SYSCONFDIR=%{_sysconfdir} \
      LOCALSTATEDIR=%{_localstatedir} \
@@ -43,7 +44,8 @@ make PREFIX=%{_prefix} \
      TOPICPREFIX=@TOPICPREFIX@ \
      VERSION=%{version} \
      DATAHOST=@DATAHOST@ \
-     'PROVIDER=@PROVIDER@'
+     'PROVIDER=@PROVIDER@' \
+     ARCH=%{_arch}
 
 
 %install


### PR DESCRIPTION
This PR introduces possibility for building aarch64 yggdrasil binaries by defining `ARCH=aarch64` env variable, i.e.:
`ARCH=aarch64 make yggd`.