### PR TITLE
fix(build): removed yggdrasil reference from the spec template

### DIFF
--- a/yggdrasil.spec.in
+++ b/yggdrasil.spec.in
@@ -65,7 +65,6 @@ make PREFIX=%{_prefix} \
 
 %files
 %doc README.md doc/tags.toml
-%{_bindir}/@SHORTNAME@
 %{_sbindir}/@SHORTNAME@d
 %config(noreplace) %{_sysconfdir}/@LONGNAME@/config.toml
 %{_unitdir}/@SHORTNAME@d.service


### PR DESCRIPTION
https://github.com/RedHatInsights/yggdrasil/commit/ffb580f55ae91beff78156fdb6a41be8bc049117 removed ygg from the source code, but it remained referenced by the spec file. This PR removes that reference to allow the RPM to be built without errors.