### PR TITLE
Improve the yggctl generate commands

### DIFF
--- a/cmd/yggctl/generate.go
+++ b/cmd/yggctl/generate.go
@@ -9,13 +9,13 @@ import (
 	"github.com/redhatinsights/yggdrasil"
 )
 
-func generateDataMessage(messageType yggdrasil.MessageType, responseTo string, directive string, bytes []byte, metadata map[string]string, version int) (*yggdrasil.Data, error) {
+func generateDataMessage(messageType yggdrasil.MessageType, responseTo string, directive string, content []byte, metadata map[string]string, version int) (*yggdrasil.Data, error) {
 	var data interface{}
-	if err := json.Unmarshal(bytes, &data); err != nil {
+	if err := json.Unmarshal(content, &data); err != nil {
 		return nil, fmt.Errorf("cannot unmarshal content: %v", err)
 	}
 
-	content, err := json.Marshal(data)
+	body, err := json.Marshal(data)
 	if err != nil {
 		return nil, fmt.Errorf("cannot marshal data: %v", err)
 	}
@@ -28,7 +28,7 @@ func generateDataMessage(messageType yggdrasil.MessageType, responseTo string, d
 		Sent:       time.Now(),
 		Directive:  directive,
 		Metadata:   metadata,
-		Content:    content,
+		Content:    body,
 	}
 
 	return &msg, nil
@@ -36,10 +36,10 @@ func generateDataMessage(messageType yggdrasil.MessageType, responseTo string, d
 
 // generateControlMessage creates a control message of the appropriate type by
 // switching on the value of messageType.
-func generateControlMessage(messageType yggdrasil.MessageType, responseTo string, version int, bytes []byte) (*yggdrasil.Control, error) {
+func generateControlMessage(messageType yggdrasil.MessageType, responseTo string, version int, content []byte) (*yggdrasil.Control, error) {
 	switch messageType {
 	case yggdrasil.MessageTypeCommand:
-		msg, err := generateCommandMessage(messageType, responseTo, version, bytes)
+		msg, err := generateCommandMessage(messageType, responseTo, version, content)
 		if err != nil {
 			return nil, fmt.Errorf("cannot generate command message: %v", err)
 		}
@@ -53,7 +53,7 @@ func generateControlMessage(messageType yggdrasil.MessageType, responseTo string
 		}
 		return &ctrl, nil
 	case yggdrasil.MessageTypeEvent:
-		msg, err := generateEventMessage(messageType, responseTo, version, bytes)
+		msg, err := generateEventMessage(messageType, responseTo, version, content)
 		if err != nil {
 			return nil, fmt.Errorf("cannot generate event message: %v", err)
 		}
@@ -72,7 +72,7 @@ func generateControlMessage(messageType yggdrasil.MessageType, responseTo string
 }
 
 // generateCommandMessage unmarshals bytes into a command message.
-func generateCommandMessage(messageType yggdrasil.MessageType, responseTo string, version int, bytes []byte) (*yggdrasil.Command, error) {
+func generateCommandMessage(messageType yggdrasil.MessageType, responseTo string, version int, content []byte) (*yggdrasil.Command, error) {
 	msg := yggdrasil.Command{
 		Type:       messageType,
 		MessageID:  uuid.New().String(),
@@ -81,21 +81,21 @@ func generateCommandMessage(messageType yggdrasil.MessageType, responseTo string
 		Sent:       time.Now(),
 	}
 
-	if err := json.Unmarshal(bytes, &msg.Content); err != nil {
+	if err := json.Unmarshal(content, &msg.Content); err != nil {
 		return nil, fmt.Errorf("cannot unmarshal content: %v", err)
 	}
 
 	return &msg, nil
 }
 
-func generateEventMessage(messageType yggdrasil.MessageType, responseTo string, version int, bytes []byte) (*yggdrasil.Event, error) {
+func generateEventMessage(messageType yggdrasil.MessageType, responseTo string, version int, content []byte) (*yggdrasil.Event, error) {
 	msg := yggdrasil.Event{
 		Type:       messageType,
 		MessageID:  uuid.New().String(),
 		ResponseTo: responseTo,
 		Version:    version,
 		Sent:       time.Now(),
-		Content:    string(bytes),
+		Content:    string(content),
 	}
 
 	return &msg, nil

--- a/cmd/yggctl/generate.go
+++ b/cmd/yggctl/generate.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/redhatinsights/yggdrasil"
+)
+
+func generateDataMessage(messageType yggdrasil.MessageType, responseTo string, directive string, bytes []byte, metadata map[string]string, version int) (*yggdrasil.Data, error) {
+	var data interface{}
+	if err := json.Unmarshal(bytes, &data); err != nil {
+		return nil, fmt.Errorf("cannot unmarshal content: %v", err)
+	}
+
+	content, err := json.Marshal(data)
+	if err != nil {
+		return nil, fmt.Errorf("cannot marshal data: %v", err)
+	}
+
+	msg := yggdrasil.Data{
+		Type:       messageType,
+		MessageID:  uuid.New().String(),
+		ResponseTo: responseTo,
+		Version:    version,
+		Sent:       time.Now(),
+		Directive:  directive,
+		Metadata:   metadata,
+		Content:    content,
+	}
+
+	return &msg, nil
+}
+
+// generateControlMessage creates a control message of the appropriate type by
+// switching on the value of messageType.
+func generateControlMessage(messageType yggdrasil.MessageType, responseTo string, version int, bytes []byte) (*yggdrasil.Control, error) {
+	switch messageType {
+	case yggdrasil.MessageTypeCommand:
+		msg, err := generateCommandMessage(messageType, responseTo, version, bytes)
+		if err != nil {
+			return nil, fmt.Errorf("cannot generate command message: %v", err)
+		}
+		data, err := json.Marshal(msg)
+		if err != nil {
+			return nil, fmt.Errorf("cannot marshal command message: %v", err)
+		}
+		var ctrl yggdrasil.Control
+		if err := json.Unmarshal(data, &ctrl); err != nil {
+			return nil, fmt.Errorf("cannot unmarshal control message: %v", err)
+		}
+		return &ctrl, nil
+	case yggdrasil.MessageTypeEvent:
+		msg, err := generateEventMessage(messageType, responseTo, version, bytes)
+		if err != nil {
+			return nil, fmt.Errorf("cannot generate event message: %v", err)
+		}
+		data, err := json.Marshal(msg)
+		if err != nil {
+			return nil, fmt.Errorf("cannot marshal command message: %v", err)
+		}
+		var ctrl yggdrasil.Control
+		if err := json.Unmarshal(data, &ctrl); err != nil {
+			return nil, fmt.Errorf("cannot unmarshal control message: %v", err)
+		}
+		return &ctrl, nil
+	default:
+		return nil, fmt.Errorf("unsupported message type: %v", messageType)
+	}
+}
+
+// generateCommandMessage unmarshals bytes into a command message.
+func generateCommandMessage(messageType yggdrasil.MessageType, responseTo string, version int, bytes []byte) (*yggdrasil.Command, error) {
+	msg := yggdrasil.Command{
+		Type:       messageType,
+		MessageID:  uuid.New().String(),
+		ResponseTo: responseTo,
+		Version:    version,
+		Sent:       time.Now(),
+	}
+
+	if err := json.Unmarshal(bytes, &msg.Content); err != nil {
+		return nil, fmt.Errorf("cannot unmarshal content: %v", err)
+	}
+
+	return &msg, nil
+}
+
+func generateEventMessage(messageType yggdrasil.MessageType, responseTo string, version int, bytes []byte) (*yggdrasil.Event, error) {
+	msg := yggdrasil.Event{
+		Type:       messageType,
+		MessageID:  uuid.New().String(),
+		ResponseTo: responseTo,
+		Version:    version,
+		Sent:       time.Now(),
+		Content:    string(bytes),
+	}
+
+	return &msg, nil
+}

--- a/cmd/yggctl/generate_test.go
+++ b/cmd/yggctl/generate_test.go
@@ -1,0 +1,171 @@
+package main
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/redhatinsights/yggdrasil"
+)
+
+type Input struct {
+	messageType string
+	responseTo  string
+	directive   string
+	content     []byte
+	metadata    map[string]string
+	version     int
+}
+
+func TestGenerateDataMessage(t *testing.T) {
+	tests := []struct {
+		description string
+		input       Input
+		want        *yggdrasil.Data
+		wantError   error
+	}{
+		{
+			description: "data JSON content",
+			input: Input{
+				messageType: "data",
+				directive:   "dir",
+				content:     []byte(`{"field":"value"}`),
+				metadata:    map[string]string{},
+				version:     1,
+			},
+			want: &yggdrasil.Data{
+				Type:      yggdrasil.MessageTypeData,
+				Version:   1,
+				Directive: "dir",
+				Metadata:  map[string]string{},
+				Content:   []byte(`{"field":"value"}`),
+			},
+		},
+		{
+			description: "data string content",
+			input: Input{
+				messageType: "data",
+				directive:   "dir",
+				content:     []byte(`"hello world"`),
+				metadata:    map[string]string{},
+				version:     1,
+			},
+			want: &yggdrasil.Data{
+				Type:      yggdrasil.MessageTypeData,
+				Version:   1,
+				Directive: "dir",
+				Metadata:  map[string]string{},
+				Content:   []byte(`"hello world"`),
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			got, err := generateDataMessage(yggdrasil.MessageType(test.input.messageType), test.input.responseTo, test.input.directive, test.input.content, test.input.metadata, test.input.version)
+
+			if test.wantError != nil {
+				if !cmp.Equal(err, test.wantError, cmpopts.EquateErrors()) {
+					t.Errorf("%#v != %#v", err, test.wantError)
+				}
+			} else {
+				if err != nil {
+					t.Fatal(err)
+				}
+				if !cmp.Equal(got, test.want, cmpopts.IgnoreFields(yggdrasil.Data{}, "MessageID", "Sent")) {
+					t.Errorf("%#v != %#v", got, test.want)
+				}
+			}
+		})
+	}
+}
+
+func TestGenerateCommandMessage(t *testing.T) {
+	tests := []struct {
+		description string
+		input       Input
+		want        *yggdrasil.Command
+		wantError   error
+	}{
+		{
+			description: "command",
+			input: Input{
+				messageType: string(yggdrasil.MessageTypeCommand),
+				content:     []byte(`{"command":"ping","arguments":{}}`),
+				version:     1,
+			},
+			want: &yggdrasil.Command{
+				Type:    yggdrasil.MessageTypeCommand,
+				Version: 1,
+				Content: struct {
+					Command   yggdrasil.CommandName "json:\"command\""
+					Arguments map[string]string     "json:\"arguments\""
+				}{
+					Command:   "ping",
+					Arguments: map[string]string{},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			got, err := generateCommandMessage(yggdrasil.MessageType(test.input.messageType), test.input.responseTo, test.input.version, test.input.content)
+
+			if test.wantError != nil {
+				if !cmp.Equal(err, test.wantError, cmpopts.EquateErrors()) {
+					t.Errorf("%#v != %#v", err, test.wantError)
+				}
+			} else {
+				if err != nil {
+					t.Fatal(err)
+				}
+				if !cmp.Equal(got, test.want, cmpopts.IgnoreFields(yggdrasil.Command{}, "MessageID", "Sent")) {
+					t.Errorf("%#v != %#v", got, test.want)
+				}
+			}
+		})
+	}
+}
+
+func TestGenerateControlMessage(t *testing.T) {
+	tests := []struct {
+		description string
+		input       Input
+		want        *yggdrasil.Control
+		wantError   error
+	}{
+		{
+			input: Input{
+				messageType: "event",
+				content:     []byte(`pong`),
+				version:     1,
+			},
+			want: &yggdrasil.Control{
+				Type:    yggdrasil.MessageTypeEvent,
+				Version: 1,
+				Content: json.RawMessage(`"pong"`),
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			got, err := generateControlMessage(yggdrasil.MessageType(test.input.messageType), test.input.responseTo, test.input.version, test.input.content)
+
+			if test.wantError != nil {
+				if !cmp.Equal(err, test.wantError, cmpopts.EquateErrors()) {
+					t.Errorf("%#v != %#v", err, test.wantError)
+				}
+			} else {
+				if err != nil {
+					t.Fatal(err)
+				}
+				if !cmp.Equal(got, test.want, cmpopts.IgnoreFields(yggdrasil.Control{}, "MessageID", "Sent")) {
+					t.Errorf("%#v != %#v", got, test.want)
+				}
+			}
+		})
+	}
+}

--- a/messages.go
+++ b/messages.go
@@ -101,6 +101,15 @@ type Event struct {
 	Content    string      `json:"content"`
 }
 
+type Control struct {
+	Type       MessageType     `json:"type"`
+	MessageID  string          `json:"message_id"`
+	ResponseTo string          `json:"response_to"`
+	Version    int             `json:"version"`
+	Sent       time.Time       `json:"sent"`
+	Content    json.RawMessage `json:"content"`
+}
+
 // Data messages are published by both client and server on their respective
 // "data" topic. The client consumes Data messages and routes them to an
 // appropriate worker based on the "Directive" field.


### PR DESCRIPTION
Previously, the yggctl generate commands relied on some quick marshalling and unmarshalling of map[string]interface{} types. This led to some bugs when trying to get JSON into the `content` field of messages. This PR updates the message generation logic to first create full yggdrasil message types, correctly populate the fields, and then marshal them into JSON before printing the message to standard output.