### PR TITLE
Backport-exclude-workers

### DIFF
--- a/cmd/yggd/exec.go
+++ b/cmd/yggd/exec.go
@@ -175,6 +175,9 @@ func watchWorkerDir(dir string, env []string, died chan int) {
 		switch e.Event() {
 		case notify.InCloseWrite, notify.InMovedTo:
 			if strings.HasSuffix(e.Path(), "worker") {
+				if ExcludeWorkers[filepath.Base(e.Path())] {
+					continue
+				}
 				log.Tracef("new worker detected: %v", e.Path())
 				go startProcess(e.Path(), env, 0, died)
 			}


### PR DESCRIPTION
Add a `--exclude-worker` command flag and configuration parameter. Any strings listed in this argument will be stored in an exclusion list at run time. If a worker's *basename* matches a string in this list, it is excluded from execution when starting worker processes. For example, `--exclude-worker echo-worker` will prevent the file `/usr/libexec/yggdrasil/echo-worker` from being executed.

Fixes: #44