### PR TITLE
feat: HTTP transport add prefix

### DIFF
--- a/cmd/yggd/config.go
+++ b/cmd/yggd/config.go
@@ -8,7 +8,7 @@ const (
 	cliServer        = "server"
 	cliSocketAddr    = "socket-addr"
 	cliClientID      = "client-id"
-	cliTopicPrefix   = "topic-prefix"
+	cliPathPrefix    = "path-prefix"
 	cliProtocol      = "protocol"
 	cliDataHost      = "data-host"
 	cliExcludeWorker = "exclude-worker"
@@ -41,9 +41,8 @@ type Config struct {
 	// the TLS configration's CA root list.
 	CaRoot string
 
-	// TopicPrefix is a value prepended to all topics when publishing and
-	// subscribing to MQTT topics.
-	TopicPrefix string
+	// PathPrefix is a value prepended at the transport level.
+	PathPrefix string
 
 	// Protocol is the protocol used by yggd when connecting to Server. Can be
 	// either MQTT or HTTP.

--- a/cmd/yggd/config.go
+++ b/cmd/yggd/config.go
@@ -41,7 +41,7 @@ type Config struct {
 	// the TLS configration's CA root list.
 	CaRoot string
 
-	// PathPrefix is a value prepended at the transport level.
+	// PathPrefix is a value prepended to all path names at the transport layer.
 	PathPrefix string
 
 	// Protocol is the protocol used by yggd when connecting to Server. Can be

--- a/cmd/yggd/main.go
+++ b/cmd/yggd/main.go
@@ -72,7 +72,7 @@ func main() {
 			Name:   cliPathPrefix,
 			Value:  yggdrasil.PathPrefix,
 			Hidden: true,
-			Usage:  "Use `PREFIX` as the MQTT topic or HTTP path prefix",
+			Usage:  "Use `PREFIX` as the transport layer path name prefix",
 		}),
 		altsrc.NewStringFlag(&cli.StringFlag{
 			Name:  cliProtocol,

--- a/cmd/yggd/main.go
+++ b/cmd/yggd/main.go
@@ -69,10 +69,10 @@ func main() {
 			Usage:  "Use `FILE` as the root CA",
 		}),
 		altsrc.NewStringFlag(&cli.StringFlag{
-			Name:   cliTopicPrefix,
-			Value:  yggdrasil.TopicPrefix,
+			Name:   cliPathPrefix,
+			Value:  yggdrasil.PathPrefix,
 			Hidden: true,
-			Usage:  "Use `PREFIX` as the MQTT topic prefix",
+			Usage:  "Use `PREFIX` as the MQTT topic or HTTP path prefix",
 		}),
 		altsrc.NewStringFlag(&cli.StringFlag{
 			Name:  cliProtocol,
@@ -147,7 +147,7 @@ func main() {
 			CertFile:       c.String(cliCertFile),
 			KeyFile:        c.String(cliKeyFile),
 			CaRoot:         c.String(cliCaRoot),
-			TopicPrefix:    c.String(cliTopicPrefix),
+			PathPrefix:     c.String(cliPathPrefix),
 			Protocol:       c.String(cliProtocol),
 			DataHost:       c.String(cliDataHost),
 			ExcludeWorkers: map[string]bool{},
@@ -158,8 +158,8 @@ func main() {
 		}
 
 		// Set TopicPrefix globally if the config option is non-zero
-		if DefaultConfig.TopicPrefix != "" {
-			yggdrasil.TopicPrefix = DefaultConfig.TopicPrefix
+		if DefaultConfig.PathPrefix != "" {
+			yggdrasil.PathPrefix = DefaultConfig.PathPrefix
 		}
 
 		// Set DataHost globally if the config option is non-zero

--- a/constants.go
+++ b/constants.go
@@ -15,7 +15,8 @@ var (
 	// BrandName is a long-form description.
 	BrandName string
 
-	// PathPrefix is used as a prefix to all MQTT topics in the client.
+	// PathPrefix is used as a prefix to all transport layer path names in the
+	// client.
 	PathPrefix string
 
 	// DataHost is used to force sending all HTTP traffic to a specific host.

--- a/constants.go
+++ b/constants.go
@@ -15,8 +15,8 @@ var (
 	// BrandName is a long-form description.
 	BrandName string
 
-	// TopicPrefix is used as a prefix to all MQTT topics in the client.
-	TopicPrefix string
+	// PathPrefix is used as a prefix to all MQTT topics in the client.
+	PathPrefix string
 
 	// DataHost is used to force sending all HTTP traffic to a specific host.
 	DataHost string
@@ -87,8 +87,8 @@ func init() {
 	if BrandName == "" {
 		BrandName = "yggdrasil"
 	}
-	if TopicPrefix == "" {
-		TopicPrefix = "yggdrasil"
+	if PathPrefix == "" {
+		PathPrefix = "yggdrasil"
 	}
 	if Provider == "" {
 		Provider = "the cloud"

--- a/internal/transport/http.go
+++ b/internal/transport/http.go
@@ -3,10 +3,12 @@ package transport
 import (
 	"crypto/tls"
 	"fmt"
+	"path/filepath"
 	"sync/atomic"
 	"time"
 
 	"git.sr.ht/~spc/go-log"
+	"github.com/redhatinsights/yggdrasil"
 	"github.com/redhatinsights/yggdrasil/internal/http"
 )
 
@@ -98,5 +100,6 @@ func (t *HTTP) send(message []byte, channel string) error {
 }
 
 func (t *HTTP) getUrl(direction string, channel string) string {
-	return fmt.Sprintf("http://%s/%s/%s/%s", t.server, channel, t.clientID, direction)
+	path := filepath.Join(yggdrasil.PathPrefix, channel, t.clientID, direction)
+	return fmt.Sprintf("http://%s/%s", t.server, path)
 }

--- a/internal/transport/mqtt.go
+++ b/internal/transport/mqtt.go
@@ -38,12 +38,12 @@ func NewMQTTTransport(clientID string, broker string, tlsConfig *tls.Config, dat
 		// Publish a throwaway message in case the topic does not exist;
 		// this is a workaround for the Akamai MQTT broker implementation.
 		go func() {
-			topic := fmt.Sprintf("%v/%v/data/out", yggdrasil.TopicPrefix, opts.ClientID())
+			topic := fmt.Sprintf("%v/%v/data/out", yggdrasil.PathPrefix, opts.ClientID())
 			c.Publish(topic, 0, false, []byte{})
 		}()
 
 		var topic string
-		topic = fmt.Sprintf("%v/%v/data/in", yggdrasil.TopicPrefix, opts.ClientID())
+		topic = fmt.Sprintf("%v/%v/data/in", yggdrasil.PathPrefix, opts.ClientID())
 		c.Subscribe(topic, 1, func(c mqtt.Client, m mqtt.Message) {
 			go func() {
 				if err := t.ReceiveData(m.Payload(), "data"); err != nil {
@@ -53,7 +53,7 @@ func NewMQTTTransport(clientID string, broker string, tlsConfig *tls.Config, dat
 		})
 		log.Tracef("subscribed to topic: %v", topic)
 
-		topic = fmt.Sprintf("%v/%v/control/in", yggdrasil.TopicPrefix, opts.ClientID())
+		topic = fmt.Sprintf("%v/%v/control/in", yggdrasil.PathPrefix, opts.ClientID())
 		c.Subscribe(topic, 1, func(c mqtt.Client, m mqtt.Message) {
 			go func() {
 				if err := t.ReceiveData(m.Payload(), "control"); err != nil {
@@ -90,7 +90,7 @@ func NewMQTTTransport(clientID string, broker string, tlsConfig *tls.Config, dat
 		return nil, fmt.Errorf("cannot marshal message to JSON: %w", err)
 	}
 
-	opts.SetBinaryWill(fmt.Sprintf("%v/%v/control/out", yggdrasil.TopicPrefix, opts.ClientID), data, 1, false)
+	opts.SetBinaryWill(fmt.Sprintf("%v/%v/control/out", yggdrasil.PathPrefix, opts.ClientID), data, 1, false)
 
 	t.client = mqtt.NewClient(opts)
 	t.receiveHandler = dataRecvFunc
@@ -117,7 +117,7 @@ func (t *MQTT) Disconnect(quiesce uint) {
 // information with dest.
 func (t *MQTT) SendData(data []byte, dest string) error {
 	opts := t.client.OptionsReader()
-	topic := fmt.Sprintf("%v/%v/%v/out", yggdrasil.TopicPrefix, opts.ClientID(), dest)
+	topic := fmt.Sprintf("%v/%v/%v/out", yggdrasil.PathPrefix, opts.ClientID(), dest)
 
 	if token := t.client.Publish(topic, 1, false, data); token.Wait() && token.Error() != nil {
 		log.Errorf("failed to publish message: %v", token.Error())


### PR DESCRIPTION
Currently yggd supports MQTT prefix, in this way adds a prefix to the
MQTT topic. This commit adds the same feature for HTTP, so adds the
prefix to the http endpoint.

Signed-off-by: Eloy Coto <eloy.coto@acalustra.com>