### PR TITLE
respect LDFLAG value from the environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ DESTDIR       ?=
 SYSTEMD_SYSTEM_UNIT_DIR  := $(shell pkg-config --variable systemdsystemunitdir systemd)
 
 # Build flags
-LDFLAGS := 
+LDFLAGS ?= 
 LDFLAGS += -X 'github.com/redhatinsights/yggdrasil.Version=$(VERSION)'
 LDFLAGS += -X 'github.com/redhatinsights/yggdrasil.ShortName=$(SHORTNAME)'
 LDFLAGS += -X 'github.com/redhatinsights/yggdrasil.LongName=$(LONGNAME)'

--- a/yggdrasil.spec.in
+++ b/yggdrasil.spec.in
@@ -5,6 +5,8 @@
 
 %define debug_package %{nil}
 
+%global buildflags -buildmode pie -compiler gc -a -v -x
+%global goldflags %{expand:-linkmode=external -compressdwarf=false -B 0x$(head -c20 /dev/urandom|od -An -tx1|tr -d ' \\n') -extldflags '%__global_ldflags'}
 
 Name:    @LONGNAME@
 Version: @VERSION@
@@ -32,6 +34,9 @@ a receiving queue for instructions to be sent to the system via a broker.
 
 
 %build
+%set_build_flags
+export BUILDFLAGS="%{buildflags}"
+export LDFLAGS="%{goldflags}"
 make PREFIX=%{_prefix} \
      SYSCONFDIR=%{_sysconfdir} \
      LOCALSTATEDIR=%{_localstatedir} \
@@ -47,6 +52,9 @@ make PREFIX=%{_prefix} \
 
 
 %install
+%set_build_flags
+export BUILDFLAGS="%{buildflags}"
+export LDFLAGS="%{goldflags}"
 make PREFIX=%{_prefix} \
      SYSCONFDIR=%{_sysconfdir} \
      LOCALSTATEDIR=%{_localstatedir} \


### PR DESCRIPTION
If LDFLAGS is set in the environment before building, the flags in the
variable will get integrated into the LDFLAGS passed to the compiler.
This enables building with environment-dependent flags.

This is actually an upstreaming of a patch applied downstream in RHEL.

Resolves: RHBZ#2023489