### PR TITLE
Enforce value passed through the --client-id flag

### DIFF
--- a/cmd/yggd/config.go
+++ b/cmd/yggd/config.go
@@ -23,6 +23,9 @@ type Config struct {
 	// transports.
 	ClientID string
 
+	// IsValidClientID
+	IsValidClientID bool
+
 	// SocketAddr is the socket address on which yggd is listening.
 	SocketAddr string
 


### PR DESCRIPTION
The ClientID should contain only the following characters
'[a-zA-Z0-9]'. This patch checks the value passed through the command
line and fails gracefully if the value is not respecting the rule.

Fix: #69

Signed-off-by: Gael Chamoulaud (Strider) <gchamoul@redhat.com>