### PR TITLE
Make cert-file and key-file required

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,13 +96,13 @@ data: $(DATA)
 	go run $(BUILDFLAGS) -ldflags "$(LDFLAGS)" ./cmd/$(patsubst %.bash,%,$@) --generate-bash-completion > $@
 
 %.1: $(GOSRC)
-	go run $(BUILDFLAGS) -ldflags "$(LDFLAGS)" ./cmd/$(patsubst %.1,%,$@) --generate-man-page > $@
+	go run $(BUILDFLAGS) -ldflags "$(LDFLAGS)" ./cmd/$(patsubst %.1,%,$@) --generate-man-page --cert-file /dev/null --key-file /dev/null > $@
 
 %.1.gz: %.1
 	gzip -k $^
 
 %-USAGE.md: $(GOSRC)
-	go run $(BUILDFLAGS) -ldflags "$(LDFLAGS)" ./cmd/$(patsubst %-USAGE.md,%,$@) --generate-markdown > $@
+	go run $(BUILDFLAGS) -ldflags "$(LDFLAGS)" ./cmd/$(patsubst %-USAGE.md,%,$@) --generate-markdown --cert-file /dev/null --key-file /dev/null > $@
 
 %: %.in Makefile
 	sed \

--- a/cmd/yggd/main.go
+++ b/cmd/yggd/main.go
@@ -53,12 +53,16 @@ func main() {
 			Usage: "Set the logging output level to `LEVEL`",
 		}),
 		altsrc.NewStringFlag(&cli.StringFlag{
-			Name:  "cert-file",
-			Usage: "Use `FILE` as the client certificate",
+			Name:      "cert-file",
+			Usage:     "Use `FILE` as the client certificate",
+			Required:  true,
+			TakesFile: true,
 		}),
 		altsrc.NewStringFlag(&cli.StringFlag{
-			Name:  "key-file",
-			Usage: "Use `FILE` as the client's private key",
+			Name:      "key-file",
+			Usage:     "Use `FILE` as the client's private key",
+			Required:  true,
+			TakesFile: true,
 		}),
 		altsrc.NewStringSliceFlag(&cli.StringSliceFlag{
 			Name:   "ca-root",


### PR DESCRIPTION
Assumptions are made by yggd 0.2.x that content will be available in the cert-file and key-file contents. When run without values for these flags, errors occur.