### PR TITLE
fix: don't parse json.rawmessage if body if empty

### DIFF
--- a/internal/http/client.go
+++ b/internal/http/client.go
@@ -97,7 +97,11 @@ func createResponse(resp *http.Response) (*Response, error) {
 		return result, fmt.Errorf("cannot read response body: %w", err)
 	}
 	log.Debugf("received HTTP %v: %v", resp.Status, strings.TrimSpace(string(data)))
-	result.Body = data
+
+	if len(data) > 0 {
+		result.Body = data
+	}
+
 	if resp.StatusCode >= 400 {
 		return result, &APIResponseError{Code: resp.StatusCode, Body: strings.TrimSpace(string(data))}
 	}


### PR DESCRIPTION
When the body is empty the ReadAll initialised a empty array with cap of
512, so when try to Marshal to Json will fail, this check that has
content.

Issue example:

```
package main

import (
	"encoding/json"
	"fmt"
)

type Response struct {
	// StatusCode response
	StatusCode int
	// Response Body
	Body json.RawMessage
	// Mestadata added by the transport, in case of http are the headers
	Metadata map[string]string
}

func test(data *Response) {
	res, err := json.Marshal(data)
	fmt.Println("Err: ", err)
	fmt.Printf("Data:%s\n", res)
	fmt.Println("---------------------------------")
}

func main() {
	fmt.Println("Test 1")
	test(&Response{StatusCode: 200, Body: []byte{}, Metadata: map[string]string{"foo": "bar"}})

	fmt.Println("Test 2")
	test(&Response{StatusCode: 200, Body: nil, Metadata: map[string]string{"foo": "bar"}})

	fmt.Println("Test 3")
	test(&Response{
		StatusCode: 200, Body: []byte(`{"foo": "aaa"}`), Metadata: map[string]string{"foo": "bar"},
	})
}
```

Output:

```
Test 1
Err:  json: error calling MarshalJSON for type json.RawMessage: unexpected end of JSON input
Data:
---------------------------------
Test 2
Err:  <nil>
Data:{"StatusCode":200,"Body":null,"Metadata":{"foo":"bar"}}
---------------------------------
Test 3
Err:  <nil>
Data:{"StatusCode":200,"Body":{"foo":"aaa"},"Metadata":{"foo":"bar"}}
```

Signed-off-by: Eloy Coto <eloy.coto@acalustra.com>