### PR TITLE
refactor: move tags to his own package

### DIFF
--- a/cmd/yggd/client.go
+++ b/cmd/yggd/client.go
@@ -12,6 +12,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/redhatinsights/yggdrasil"
 	"github.com/redhatinsights/yggdrasil/internal/transport"
+	"github.com/redhatinsights/yggdrasil/pkg/tags"
 )
 
 type Client struct {
@@ -163,7 +164,7 @@ func (c *Client) ConnectionStatus() (*yggdrasil.ConnectionStatus, error) {
 	var tagMap map[string]string
 	if _, err := os.Stat(tagsFilePath); !os.IsNotExist(err) {
 		var err error
-		tagMap, err = readTagsFile(tagsFilePath)
+		tagMap, err = tags.ReadTagsFile(tagsFilePath)
 		if err != nil {
 			log.Errorf("cannot load tags: %v", err)
 		}

--- a/pkg/tags/tags.go
+++ b/pkg/tags/tags.go
@@ -1,4 +1,4 @@
-package main
+package tags
 
 import (
 	"fmt"
@@ -61,7 +61,7 @@ func readTags(in io.Reader) (map[string]string, error) {
 }
 
 // readTagsFile reads tag data from file.
-func readTagsFile(file string) (map[string]string, error) {
+func ReadTagsFile(file string) (map[string]string, error) {
 	f, err := os.Open(file)
 	if err != nil {
 		return nil, fmt.Errorf("cannot open '%v' for reading: %w", file, err)

--- a/pkg/tags/tags_test.go
+++ b/pkg/tags/tags_test.go
@@ -1,4 +1,4 @@
-package main
+package tags
 
 import (
 	"io"


### PR DESCRIPTION
To be able to consume tags files from any worker with the same values as
yggdrasil.

Signed-off-by: Eloy Coto <eloy.coto@acalustra.com>