### PR TITLE
fix: Using right cert on cannonicalFacts

### DIFF
--- a/canonical_facts.go
+++ b/canonical_facts.go
@@ -99,7 +99,7 @@ func CanonicalFactsFromMap(m map[string]interface{}) (*CanonicalFacts, error) {
 
 // GetCanonicalFacts attempts to construct a CanonicalFacts struct by collecting
 // data from the localhost.
-func GetCanonicalFacts() (*CanonicalFacts, error) {
+func GetCanonicalFacts(certFile string) (*CanonicalFacts, error) {
 	var facts CanonicalFacts
 	var err error
 
@@ -128,7 +128,7 @@ func GetCanonicalFacts() (*CanonicalFacts, error) {
 		facts.BIOSUUID = BIOSUUID
 	}
 
-	facts.SubscriptionManagerID, err = readCert("/etc/pki/consumer/cert.pem")
+	facts.SubscriptionManagerID, err = readCert(certFile)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/yggd/client.go
+++ b/cmd/yggd/client.go
@@ -153,7 +153,7 @@ func (c *Client) ReceiveData() {
 // ConnectionStatus creates a connection-status message using the current state
 // of the client.
 func (c *Client) ConnectionStatus() (*yggdrasil.ConnectionStatus, error) {
-	facts, err := yggdrasil.GetCanonicalFacts()
+	facts, err := yggdrasil.GetCanonicalFacts(DefaultConfig.CertFile)
 	if err != nil {
 		return nil, fmt.Errorf("cannot get canonical facts: %w", err)
 	}


### PR DESCRIPTION
Because now cert-file can be set, the cannonicalFacts is still trying to
get the cert from invalid place, given an invalid message to the user.

Signed-off-by: Eloy Coto <eloy.coto@acalustra.com>