### PR TITLE
Fix: change permissions on make srpm

### DIFF
--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -3,6 +3,7 @@ include Makefile
 SOURCEDIR := $(shell rpmbuild -E %_sourcedir)
 SRCRPMDIR := $(shell rpmbuild -E %_srcrpmdir)
 
+srpm: $(shell chown $(shell whoami):$(shell id -g) . -R)
 srpm: SHORTNAME = $(shell basename $(PWD))
 srpm: LONGNAME = $(SHORTNAME)
 srpm: BRANDNAME = $(SHORTNAME)


### PR DESCRIPTION
With the new release of fedora/centos9, some issues with Git regarding
safe-directories.

Fedora-copr clone the repo as mockbuild user, and when doing git rev
list failed with the following message.

```
fatal: unsafe repository ('/mnt/workdir-mupe3qpk/yggdrasil' is owned by someone else)
To add an exception for this directory, call:

	git config --global --add safe.directory /mnt/workdir-mupe3qpk/yggdrasil
```

Tried with safe-directories, but results didn't work as expected, so
chown the code to the right user was the best thing in this case.

Signed-off-by: Eloy Coto <eloy.coto@acalustra.com>