### PR TITLE
systemd: Add support for an environment file

### DIFF
--- a/data/systemd/yggd.service.in
+++ b/data/systemd/yggd.service.in
@@ -6,6 +6,7 @@ Requires=network-online.target
 
 [Service]
 Type=simple
+EnvironmentFile=-/etc/sysconfig/@SHORTNAME@
 ExecStart=@SBINDIR@/@SHORTNAME@d
 
 [Install]


### PR DESCRIPTION
This will allow to create an environment file like /etc/sysconfig/rhc to set an http proxy or similar. This is needed e.g. for using the internal console staging environment.