### PR TITLE
fix: remove unused config options

### DIFF
--- a/cmd/yggd/main.go
+++ b/cmd/yggd/main.go
@@ -95,17 +95,6 @@ func main() {
 			Name:  config.FlagNameClientID,
 			Usage: "Use `VALUE` as the client ID when connecting",
 		}),
-		altsrc.NewStringSliceFlag(&cli.StringSliceFlag{
-			Name:  config.FlagNameExcludeWorker,
-			Usage: "Exclude `WORKER` from activation when starting workers",
-		}),
-		altsrc.NewPathFlag(&cli.PathFlag{
-			Name:      config.FlagNameWorkerConfigDir,
-			Usage:     "Load workers from `DIR`",
-			TakesFile: true,
-			Hidden:    true,
-			Value:     filepath.Join(yggdrasil.SysconfDir, yggdrasil.LongName, "workers"),
-		}),
 		altsrc.NewPathFlag(&cli.PathFlag{
 			Name:      config.FlagNameCanonicalFacts,
 			Usage:     "Read canonical facts from `FILE`",
@@ -145,18 +134,16 @@ func main() {
 		}
 
 		config.DefaultConfig = config.Config{
-			LogLevel:        c.String(config.FlagNameLogLevel),
-			ClientID:        c.String(config.FlagNameClientID),
-			Server:          c.String(config.FlagNameServer),
-			CertFile:        c.String(config.FlagNameCertFile),
-			KeyFile:         c.String(config.FlagNameKeyFile),
-			CARoot:          c.StringSlice(config.FlagNameCaRoot),
-			PathPrefix:      c.String(config.FlagNamePathPrefix),
-			Protocol:        c.String(config.FlagNameProtocol),
-			DataHost:        c.String(config.FlagNameDataHost),
-			ExcludeWorkers:  map[string]bool{},
-			WorkerConfigDir: c.String(config.FlagNameWorkerConfigDir),
-			CanonicalFacts:  c.String(config.FlagNameCanonicalFacts),
+			LogLevel:       c.String(config.FlagNameLogLevel),
+			ClientID:       c.String(config.FlagNameClientID),
+			Server:         c.String(config.FlagNameServer),
+			CertFile:       c.String(config.FlagNameCertFile),
+			KeyFile:        c.String(config.FlagNameKeyFile),
+			CARoot:         c.StringSlice(config.FlagNameCaRoot),
+			PathPrefix:     c.String(config.FlagNamePathPrefix),
+			Protocol:       c.String(config.FlagNameProtocol),
+			DataHost:       c.String(config.FlagNameDataHost),
+			CanonicalFacts: c.String(config.FlagNameCanonicalFacts),
 		}
 
 		tlsConfig, err := config.DefaultConfig.CreateTLSConfig()
@@ -167,10 +154,6 @@ func main() {
 		TlSEvents, err := config.DefaultConfig.WatcherUpdate()
 		if err != nil {
 			return cli.Exit(fmt.Errorf("cannot start watching for certificate changes: %w", err), 1)
-		}
-
-		for _, worker := range c.StringSlice(config.FlagNameExcludeWorker) {
-			config.DefaultConfig.ExcludeWorkers[worker] = true
 		}
 
 		// Set up a channel to receive the TERM or INT signal over and clean up

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -10,19 +10,17 @@ import (
 )
 
 const (
-	FlagNameLogLevel        = "log-level"
-	FlagNameCertFile        = "cert-file"
-	FlagNameKeyFile         = "key-file"
-	FlagNameCaRoot          = "ca-root"
-	FlagNameServer          = "server"
-	FlagNameSocketAddr      = "socket-addr"
-	FlagNameClientID        = "client-id"
-	FlagNamePathPrefix      = "path-prefix"
-	FlagNameProtocol        = "protocol"
-	FlagNameDataHost        = "data-host"
-	FlagNameExcludeWorker   = "exclude-worker"
-	FlagNameWorkerConfigDir = "worker-config-dir"
-	FlagNameCanonicalFacts  = "canonical-facts"
+	FlagNameLogLevel       = "log-level"
+	FlagNameCertFile       = "cert-file"
+	FlagNameKeyFile        = "key-file"
+	FlagNameCaRoot         = "ca-root"
+	FlagNameServer         = "server"
+	FlagNameSocketAddr     = "socket-addr"
+	FlagNameClientID       = "client-id"
+	FlagNamePathPrefix     = "path-prefix"
+	FlagNameProtocol       = "protocol"
+	FlagNameDataHost       = "data-host"
+	FlagNameCanonicalFacts = "canonical-facts"
 )
 
 var DefaultConfig = Config{
@@ -63,14 +61,6 @@ type Config struct {
 	// DataHost is a hostname value to interject into all HTTP requests when
 	// handling data retrieval for "detachedContent" workers.
 	DataHost string
-
-	// ExcludeWorkers contains worker names to be excluded from starting when
-	// yggd starts.
-	ExcludeWorkers map[string]bool
-
-	// WorkerConfigDir is a path to a directory containing worker configuration
-	// files. This directory is read during worker discovery and startup.
-	WorkerConfigDir string
 
 	// CanonicalFacts is a path to a JSON file containing "canonical facts",
 	// a set of facts about the system used to uniquely identify it.


### PR DESCRIPTION
Remove exclude-workers and worker-config-dir options. Both are no longer
used due to the removal of worker process management.

Fixes: #106 
Fixes: #107 