### PR TITLE
feat: multiple brokers

### DIFF
--- a/cmd/yggd/main.go
+++ b/cmd/yggd/main.go
@@ -74,7 +74,7 @@ func main() {
 			Usage: "Transmit data remotely using `PROTOCOL` ('mqtt' or 'http')",
 			Value: "mqtt",
 		}),
-		altsrc.NewStringFlag(&cli.StringFlag{
+		altsrc.NewStringSliceFlag(&cli.StringSliceFlag{
 			Name:  config.FlagNameServer,
 			Usage: "Connect the client to the specified `URI`",
 		}),
@@ -136,7 +136,7 @@ func main() {
 		config.DefaultConfig = config.Config{
 			LogLevel:       c.String(config.FlagNameLogLevel),
 			ClientID:       c.String(config.FlagNameClientID),
-			Server:         c.String(config.FlagNameServer),
+			Server:         c.StringSlice(config.FlagNameServer),
 			CertFile:       c.String(config.FlagNameCertFile),
 			KeyFile:        c.String(config.FlagNameKeyFile),
 			CARoot:         c.StringSlice(config.FlagNameCaRoot),
@@ -215,7 +215,7 @@ func main() {
 			}
 		case "http":
 			var err error
-			transporter, err = transport.NewHTTPTransport(config.DefaultConfig.ClientID, config.DefaultConfig.Server, tlsConfig, UserAgent, time.Second*5)
+			transporter, err = transport.NewHTTPTransport(config.DefaultConfig.ClientID, config.DefaultConfig.Server[0], tlsConfig, UserAgent, time.Second*5)
 			if err != nil {
 				return cli.Exit(fmt.Errorf("cannot create HTTP transport: %w", err), 1)
 			}

--- a/data/yggdrasil/config.toml
+++ b/data/yggdrasil/config.toml
@@ -1,5 +1,5 @@
 # yggdrasil global configuration settings
 
 protocol = "mqtt"
-server = "tcp://test.mosquitto.org:1883"
+server = ["tcp://test.mosquitto.org:1883"]
 log-level = "error"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -37,7 +37,7 @@ type Config struct {
 	ClientID string
 
 	// Server is a URI to which yggd connects in order to send and receive data.
-	Server string
+	Server []string
 
 	// CertFile is a path to a public certificate, optionally used along with
 	// KeyFile to authenticate connections.

--- a/internal/transport/mqtt.go
+++ b/internal/transport/mqtt.go
@@ -26,7 +26,7 @@ type MQTT struct {
 
 // NewMQTTTransport creates a transport suitable for transmitting data over a
 // set of MQTT topics.
-func NewMQTTTransport(clientID string, broker string, tlsConfig *tls.Config) (*MQTT, error) {
+func NewMQTTTransport(clientID string, brokers []string, tlsConfig *tls.Config) (*MQTT, error) {
 	var t MQTT
 
 	t.events = make(chan TransporterEvent)
@@ -36,7 +36,9 @@ func NewMQTTTransport(clientID string, broker string, tlsConfig *tls.Config) (*M
 	}
 
 	opts := mqtt.NewClientOptions()
-	opts.AddBroker(broker)
+	for _, broker := range brokers {
+		opts.AddBroker(broker)
+	}
 	opts.SetClientID(clientID)
 	opts.SetTLSConfig(tlsConfig.Clone())
 	opts.SetCleanSession(true)


### PR DESCRIPTION
The MQTT transport supports the notion of multiple brokers; while the
HTTP transport does not, we can still support both by converting the
--server flag into a string slice. The HTTP transport is created with
only the first element of the string slice flag, while the MQTT
transport accepts the entire slice. Each broker in the slice is added
during the connection process of the MQTT transport.

Fixes: #80