### PR TITLE
Added cancel message option to make data message cancellables

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -182,7 +182,7 @@ for publishing messages and subscribing to topics on an MQTT broker. `mqttcli`
 can be installed with `go install`:
 
 ```
-go install git.sr.ht/~spc/mqttcli/cmd/...
+go install git.sr.ht/~spc/mqttcli/cmd/...@latest
 ```
 
 Or if you're running Fedora 34 or later, it can be installed directly with

--- a/cmd/yggctl/generate.go
+++ b/cmd/yggctl/generate.go
@@ -9,7 +9,7 @@ import (
 	"github.com/redhatinsights/yggdrasil"
 )
 
-func generateDataMessage(messageType yggdrasil.MessageType, responseTo string, directive string, content []byte, metadata map[string]string, version int) (*yggdrasil.Data, error) {
+func generateDataMessage(messageType yggdrasil.MessageType, responseTo string, directive string, content []byte, metadata map[string]string, version int, cancelID string) (*yggdrasil.Data, error) {
 	msg := yggdrasil.Data{
 		Type:       messageType,
 		MessageID:  uuid.New().String(),
@@ -17,6 +17,7 @@ func generateDataMessage(messageType yggdrasil.MessageType, responseTo string, d
 		Version:    version,
 		Sent:       time.Now(),
 		Directive:  directive,
+		CancelID:   cancelID,
 		Metadata:   metadata,
 		Content:    content,
 	}

--- a/cmd/yggctl/generate_test.go
+++ b/cmd/yggctl/generate_test.go
@@ -13,6 +13,7 @@ type Input struct {
 	messageType string
 	responseTo  string
 	directive   string
+	cancelID    string
 	content     []byte
 	metadata    map[string]string
 	version     int
@@ -30,6 +31,7 @@ func TestGenerateDataMessage(t *testing.T) {
 			input: Input{
 				messageType: "data",
 				directive:   "dir",
+				cancelID:    "message-id",
 				content:     []byte(`{"field":"value"}`),
 				metadata:    map[string]string{},
 				version:     1,
@@ -38,6 +40,7 @@ func TestGenerateDataMessage(t *testing.T) {
 				Type:      yggdrasil.MessageTypeData,
 				Version:   1,
 				Directive: "dir",
+				CancelID:  "message-id",
 				Metadata:  map[string]string{},
 				Content:   []byte(`{"field":"value"}`),
 			},
@@ -47,6 +50,7 @@ func TestGenerateDataMessage(t *testing.T) {
 			input: Input{
 				messageType: "data",
 				directive:   "dir",
+				cancelID:    "",
 				content:     []byte(`"hello world"`),
 				metadata:    map[string]string{},
 				version:     1,
@@ -55,6 +59,7 @@ func TestGenerateDataMessage(t *testing.T) {
 				Type:      yggdrasil.MessageTypeData,
 				Version:   1,
 				Directive: "dir",
+				CancelID:  "",
 				Metadata:  map[string]string{},
 				Content:   []byte(`"hello world"`),
 			},
@@ -63,7 +68,7 @@ func TestGenerateDataMessage(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {
-			got, err := generateDataMessage(yggdrasil.MessageType(test.input.messageType), test.input.responseTo, test.input.directive, test.input.content, test.input.metadata, test.input.version)
+			got, err := generateDataMessage(yggdrasil.MessageType(test.input.messageType), test.input.responseTo, test.input.directive, test.input.content, test.input.metadata, test.input.version, test.input.cancelID)
 
 			if test.wantError != nil {
 				if !cmp.Equal(err, test.wantError, cmpopts.EquateErrors()) {

--- a/cmd/yggctl/main.go
+++ b/cmd/yggctl/main.go
@@ -68,6 +68,11 @@ func main() {
 							Required: true,
 							Usage:    "set directive to `STRING`",
 						},
+						&cli.StringFlag{
+							Name:    "cancel",
+							Aliases: []string{"c"},
+							Usage:   "MessageId to be canceled",
+						},
 					},
 					Action: func(c *cli.Context) error {
 						var metadata map[string]string
@@ -75,7 +80,7 @@ func main() {
 							return cli.Exit(fmt.Errorf("cannot unmarshal metadata: %w", err), 1)
 						}
 
-						data, err := generateMessage("data", c.String("response-to"), c.String("directive"), c.Args().First(), metadata, c.Int("version"))
+						data, err := generateMessage("data", c.String("response-to"), c.String("directive"), c.Args().First(), c.String("cancel"), metadata, c.Int("version"))
 						if err != nil {
 							return cli.Exit(fmt.Errorf("cannot marshal message: %w", err), 1)
 						}
@@ -109,7 +114,7 @@ func main() {
 						},
 					},
 					Action: func(c *cli.Context) error {
-						data, err := generateMessage(c.String("type"), c.String("response-to"), "", c.Args().First(), nil, c.Int("version"))
+						data, err := generateMessage(c.String("type"), c.String("response-to"), "", c.Args().First(), c.String("cancel"), nil, c.Int("version"))
 						if err != nil {
 							return cli.Exit(fmt.Errorf("cannot marshal message: %w", err), 1)
 						}
@@ -334,10 +339,10 @@ func main() {
 	}
 }
 
-func generateMessage(messageType, responseTo, directive, content string, metadata map[string]string, version int) ([]byte, error) {
+func generateMessage(messageType, responseTo, directive, content string, cancel string, metadata map[string]string, version int) ([]byte, error) {
 	switch messageType {
 	case "data":
-		msg, err := generateDataMessage(yggdrasil.MessageType(messageType), responseTo, directive, []byte(content), metadata, version)
+		msg, err := generateDataMessage(yggdrasil.MessageType(messageType), responseTo, directive, []byte(content), metadata, version, cancel)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/work/dispatcher.go
+++ b/internal/work/dispatcher.go
@@ -194,7 +194,7 @@ func (d *Dispatcher) Dispatch(data yggdrasil.Data) error {
 		data.Content = content
 	}
 
-	call := obj.Call("com.redhat.Yggdrasil1.Worker1.Dispatch", 0, data.Directive, data.MessageID, data.ResponseTo, data.Metadata, data.Content)
+	call := obj.Call("com.redhat.Yggdrasil1.Worker1.Dispatch", 0, data.Directive, data.MessageID, data.ResponseTo, data.CancelID, data.Metadata, data.Content)
 	if err := call.Store(); err != nil {
 		return fmt.Errorf("cannot call Dispatch method on worker: %v", err)
 	}
@@ -234,7 +234,7 @@ func (d *Dispatcher) EmitEvent(event ipc.DispatcherEvent) error {
 }
 
 // Transmit implements the com.redhat.Yggdrasil1.Dispatcher1.Transmit method.
-func (d *Dispatcher) Transmit(sender dbus.Sender, addr string, messageID string, responseTo string, metadata map[string]string, data []byte) (responseCode int, responseMetadata map[string]string, responseData []byte, responseError *dbus.Error) {
+func (d *Dispatcher) Transmit(sender dbus.Sender, addr string, messageID string, responseTo string, cancelID string, metadata map[string]string, data []byte) (responseCode int, responseMetadata map[string]string, responseData []byte, responseError *dbus.Error) {
 	name, err := d.senderName(sender)
 	if err != nil {
 		return TransmitResponseErr, nil, nil, NewDBusError("Transmit", fmt.Sprintf("cannot get name for sender: %v", err))
@@ -281,6 +281,7 @@ func (d *Dispatcher) Transmit(sender dbus.Sender, addr string, messageID string,
 			Version:    1,
 			Sent:       time.Now(),
 			Directive:  addr,
+			CancelID:   cancelID,
 			Metadata:   metadata,
 			Content:    data,
 		},

--- a/messages.go
+++ b/messages.go
@@ -121,6 +121,7 @@ type Data struct {
 	Version    int               `json:"version"`
 	Sent       time.Time         `json:"sent"`
 	Directive  string            `json:"directive"`
+	CancelID   string            `json:"cancel_id"`
 	Metadata   map[string]string `json:"metadata"`
 	Content    []byte            `json:"content"`
 }


### PR DESCRIPTION
Changes made:

- New parameter to data messages type.
- Cancel parameter is the Message ID of the running message to be cancelled.
- Modify all the methods that used this message type.
- Modify the worker to use the cancel parameter.

When applied this commit it will add a new parameter in the Data Message structure. This parameter will bring the ability to cancel previous messages, thus abort its execution.

The new parameter is a string type, it will contain the `MessageID` of the previous sent message that will be cancelled.
New data messages will have the following format:
```json
{
"type":"data",
"message_id":"5c98d18f-ee97-4089-888b-8bdef3e978f5",
"response_to":"",
"version":1,
"sent":"2023-04-13T12:11:41.802864903+02:00",
"directive":"echo"
,"cancel":"5a78f699-aaee-4103-8f58-9eea7216e2b3",
"metadata":{},
"content":"aGVsbG8="
}
```

The commit modifies the worker adding the ability to cancel an echoing execution. This will only works if it runs in sleep mode. 

