### PR TITLE
Remove send_destination_prefix

### DIFF
--- a/data/dbus/yggd.conf
+++ b/data/dbus/yggd.conf
@@ -9,10 +9,6 @@
     <allow own="com.redhat.Yggdrasil1.Dispatcher1"/>
     <allow own_prefix="com.redhat.Yggdrasil1.Worker1"/>
 
-    <!-- Only root can send messages to the Worker1 interface. -->
-    <allow send_destination_prefix="com.redhat.Yggdrasil1.Worker1" send_interface="com.redhat.Yggdrasil1.Worker1"/>
-    <allow send_destination_prefix="com.redhat.Yggdrasil1.Worker1" send_interface="org.freedesktop.DBus.Properties"/>
-
     <!-- Only root can send messages to Dispatcher1 destination. -->
     <allow send_destination="com.redhat.Yggdrasil1.Dispatcher1"/>
 

--- a/data/systemd/meson.build
+++ b/data/systemd/meson.build
@@ -1,5 +1,5 @@
-systemd_system_unit_dir = systemd.get_variable(pkgconfig: 'systemd_system_unit_dir')
-systemd_user_unit_dir = systemd.get_variable(pkgconfig: 'systemd_user_unit_dir')
+systemd_system_unit_dir = systemd.get_variable(pkgconfig: 'systemdsystemunitdir')
+systemd_user_unit_dir = systemd.get_variable(pkgconfig: 'systemduserunitdir')
 
 yggdrasil_service = configure_file(
   configuration: config_data,

--- a/meson.build
+++ b/meson.build
@@ -5,7 +5,7 @@ project('yggdrasil',
 go = find_program('go')
 
 dbus = dependency('dbus-1', version: '>=1.12')
-systemd = dependency('systemd')
+systemd = dependency('systemd', version: '>=239')
 bash_completion = dependency('bash-completion')
 
 if get_option('vendor')

--- a/meson.build
+++ b/meson.build
@@ -4,7 +4,7 @@ project('yggdrasil',
 
 go = find_program('go')
 
-dbus = dependency('dbus-1', version: '>=1.14')
+dbus = dependency('dbus-1', version: '>=1.12')
 systemd = dependency('systemd')
 bash_completion = dependency('bash-completion')
 

--- a/worker/echo/com.redhat.Yggdrasil1.Worker1.echo.conf
+++ b/worker/echo/com.redhat.Yggdrasil1.Worker1.echo.conf
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!DOCTYPE busconfig PUBLIC
+ "-//freedesktop//DTD D-BUS Bus Configuration 1.0//EN"
+ "https://dbus.freedesktop.org/doc/busconfig.dtd">
+ <busconfig>
+ <policy user="root">
+    <!-- Only root can send messages to the Worker1.echo destination. -->
+    <allow send_destination="com.redhat.Yggdrasil1.Worker1.echo" send_interface="com.redhat.Yggdrasil1.Worker1"/>
+    <allow send_destination="com.redhat.Yggdrasil1.Worker1.echo" send_interface="org.freedesktop.DBus.Properties"/>
+    <allow send_destination="com.redhat.Yggdrasil1.Worker1.echo" send_interface="org.freedesktop.DBus.Introspectable"/>
+</policy>
+</busconfig>

--- a/worker/echo/com.redhat.Yggdrasil1.Worker1.echo.service.in
+++ b/worker/echo/com.redhat.Yggdrasil1.Worker1.echo.service.in
@@ -1,3 +1,4 @@
 [D-BUS Service]
 Name=com.redhat.Yggdrasil1.Worker1.echo
+User=root
 Exec=@libexecdir@/yggdrasil/echo

--- a/worker/echo/meson.build
+++ b/worker/echo/meson.build
@@ -13,3 +13,7 @@ configure_file(
   install: true,
   install_dir: dbus.get_variable(pkgconfig: 'system_bus_services_dir')
 )
+
+install_data('com.redhat.Yggdrasil1.Worker1.echo.conf',
+  install_dir: join_paths(dbus.get_variable(pkgconfig: 'datadir'), 'dbus-1', 'system.d')
+)


### PR DESCRIPTION
Remove the use of the send_destination_prefix attribute from yggd's
busconfig policy. Instead, each worker must install their own busconfig
policy. Update the echo worker to demonstrate this.

Signed-off-by: Link Dupont <link@sub-pop.net>