### PR TITLE
Added new command message: Cancel

### DIFF
--- a/ipc/com.redhat.Yggdrasil1.Worker1.xml
+++ b/ipc/com.redhat.Yggdrasil1.Worker1.xml
@@ -27,7 +27,17 @@
             <arg type="a{ss}" name="metadata" direction="in" />
             <arg type="ay" name="data" direction="in" />
         </method>
-
+        <!--
+            Cancel:
+            @directive: worker identifier for which the cancel is destined.
+            @id: unique ID of the message.
+            @cancel_id: unique ID of the message to cancel.
+        -->
+        <method name="Cancel">
+            <arg type="s" name="directive" direction="in" />
+            <arg type="s" name="id" direction="in" />
+            <arg type="s" name="cancel_id" direction="in" />
+        </method>
         <!-- 
             Features:
 

--- a/messages.go
+++ b/messages.go
@@ -43,6 +43,9 @@ const (
 
 	// CommandNameDisconnect instructs a client to permanently disconnect.
 	CommandNameDisconnect CommandName = "disconnect"
+
+	// CommandNameCancel instructs a client to cancel a previous message.
+	CommandNameCancel CommandName = "cancel"
 )
 
 // EventName represents accepted values for the "event" field of an Event

--- a/worker/echo/main.go
+++ b/worker/echo/main.go
@@ -12,6 +12,7 @@ import (
 
 	"git.sr.ht/~spc/go-log"
 
+	"github.com/redhatinsights/yggdrasil/internal/sync"
 	"github.com/redhatinsights/yggdrasil/ipc"
 	"github.com/redhatinsights/yggdrasil/worker"
 )
@@ -19,10 +20,15 @@ import (
 var sleepTime time.Duration
 var loopIt int
 
-// echo opens a new dbus connection and calls the
-// com.redhat.Yggdrasil1.Dispatcher1.Transmit method, returning the
-// metadata and data. New ID is generated for the message, and
-// response_to is set to the ID of the message we received.
+// syncMapCancelChan is a map of channels that maps message ID and its current
+// work. This allows for the cancellation of a message that has not finished.
+var syncMapCancelChan sync.RWMutexMap[chan struct{}]
+
+// echo handles the echo message and sets the channel that will manage the
+// cancel message. It runs a loop and a sleep according to the loop and
+// sleep parameters, then calls the echo function to transmit the
+// message. If there is a cancellation message during the loop or the sleep
+// time, it will cancel the transmission of the message and finish the work.
 func echo(
 	w *worker.Worker,
 	addr string,
@@ -40,6 +46,9 @@ func echo(
 		return fmt.Errorf("cannot call EmitEvent: %w", err)
 	}
 
+	// Setting the channel to handle cancellation
+	syncMapCancelChan.Set(rcvId, make(chan struct{}))
+
 	// Loop the echoes
 	for i := 0; i < loopIt; i++ {
 		// Sleep time between receiving the message and sending it
@@ -47,32 +56,79 @@ func echo(
 			log.Infof("sleeping: %v", sleepTime)
 			time.Sleep(sleepTime)
 		}
-
-		// Set "response_to" according to the rcvId of the message we received
-		echoResponseTo := rcvId
-		// Create new echoId for the message we are going to send
-		echoId := uuid.New().String()
-
-		responseCode, responseMetadata, responseData, err := w.Transmit(
-			addr,
-			echoId,
-			echoResponseTo,
-			metadata,
-			data,
-		)
-		if err != nil {
-			return fmt.Errorf("cannot call Transmit: %w", err)
+		// Cancel message if it has been sent a cancel message
+		// during sleep time or during the loop
+		cancelChan, _ := syncMapCancelChan.Get(rcvId)
+		select {
+		case <-cancelChan:
+			// if the channel is close delete the channel from map
+			// it will not be longer used.
+			log.Tracef("canceled echo message id: %v", rcvId)
+			log.Tracef("deleting channel from map")
+			syncMapCancelChan.Del(rcvId)
+			return nil
+		default:
+			if err := sendEchoMessage(w, addr, rcvId, responseTo, metadata, data, i); err != nil {
+				return err
+			}
 		}
 
-		// Log the responses received from the Dispatcher, if any.
-		log.Infof("responseCode = %v", responseCode)
-		log.Infof("responseMetadata = %#v", responseMetadata)
-		log.Infof("responseData = %v", responseData)
-		log.Infof("message %v of %v", i+1, loopIt)
+	}
 
-		if err := w.SetFeature("DispatchedAt", time.Now().Format(time.RFC3339)); err != nil {
-			return fmt.Errorf("cannot set feature: %w", err)
-		}
+	log.Tracef("deleting channel from map")
+	syncMapCancelChan.Del(rcvId)
+	return nil
+}
+
+// sendEchoMessage opens a new dbus connection and calls the
+// com.redhat.Yggdrasil1.Dispatcher1.Transmit method, returning the
+// metadata and data. New ID is generated for the message, and
+// response_to is set to the ID of the message we received.
+func sendEchoMessage(
+	w *worker.Worker,
+	addr string,
+	rcvId string,
+	responseTo string,
+	metadata map[string]string,
+	data []byte,
+	count int,
+) error {
+	// Set "response_to" according to the rcvId of the message we received
+	echoResponseTo := rcvId
+	// Create new echoId for the message we are going to send
+	echoId := uuid.New().String()
+
+	responseCode, responseMetadata, responseData, err := w.Transmit(
+		addr,
+		echoId,
+		echoResponseTo,
+		metadata,
+		data,
+	)
+	if err != nil {
+		return fmt.Errorf("cannot call Transmit: %w", err)
+	}
+
+	// Log the responses received from the Dispatcher, if any.
+	log.Infof("responseCode = %v", responseCode)
+	log.Infof("responseMetadata = %#v", responseMetadata)
+	log.Infof("responseData = %v", responseData)
+	log.Infof("message %v of %v", count+1, loopIt)
+
+	if err := w.SetFeature("DispatchedAt", time.Now().Format(time.RFC3339)); err != nil {
+		return fmt.Errorf("cannot set feature: %w", err)
+	}
+	return nil
+}
+
+// cancelEcho receives a cancel message id via com.redhat.Yggdrasil1.Worker1.Cancel method
+// closes the channel associated with that message to cancel its current run
+func cancelEcho(w *worker.Worker, addr string, id string, cancelID string) error {
+	log.Infof("cancelling message with id %v", cancelID)
+	if cancelChan, exists := syncMapCancelChan.Get(cancelID); exists {
+		close(cancelChan)
+	} else {
+		return fmt.Errorf("message with given id: %v does not exist and cannot be canceled", cancelID)
 	}
 
 	return nil
@@ -107,6 +163,7 @@ func main() {
 		"echo",
 		remoteContent,
 		map[string]string{"DispatchedAt": "", "Version": "1"},
+		cancelEcho,
 		echo,
 		events,
 	)


### PR DESCRIPTION
# Proposal

Add a new control message of type command that can be used to cancel a work that is already in progress in a worker. 
`yggd` will receive this command and forward it to the appropriate worker. If this worker implements the cancellation feature it will stop or cancel its work. But it is up to the worker to implement this functionality. 

 This PR also provides an example of how the cancellation message can be implemented in the `echo worker`. It uses a map of synchronized channels to manage the current work, and to send the cancellation message to the `goroutines` that are handle it. 

### This commit adds:

- A new command  message that can be use to cancel work in progress that is done in the workers.Is send as a command to yggdrasil client. Yggdrasil will send this message to the workers Cancel method.

- A new function to the worker, CancelRX. This function will handle the cancel signal in workers side. If it is null the worker doesn't support cancellation of messages.

- echo worker implements this cancel function to handle cancellation when it runs in slow mode.

## How to test it
Follow the [Quickstart](https://github.com/RedHatInsights/yggdrasil/blob/main/CONTRIBUTING.md#quickstart) steps to set the environment. With the following changes:

**Terminal 2**
Run the worker with the loop and sleep parameters, this will allow some time to launch the cancel message.

```
go run ./worker/echo --log-level trace --loop 10 --sleep 10s
```

**Terminal 4**
Run the hello world, that will send a new job to the worker.
```
echo "hello world"| \
go run ./cmd/yggctl generate data-message --directive echo - | \
pub -broker tcp://localhost:1883 -topic yggdrasil/$(hostname)/data/in
```

In the worker it will appear the `id` of that message:
```
2023/10/06 12:21:58 addr = echo
2023/10/06 12:21:58 id = 67c40762-2343-48ad-9bf1-23a9b98bdacb
2023/10/06 12:21:58 responseTo = 
2023/10/06 12:21:58 metadata = map[string]string{}
2023/10/06 12:21:58 data = [104 101 108 108 111 32 119 111 114 108 100 10]
2023/10/06 12:21:58 emitting event BEGIN
```

Use the id **67c40762-2343-48ad-9bf1-23a9b98bdacb** to send the cancellation message:
```
echo '{"command":"cancel", "arguments":{"directive":"echo","messageID":"67c40762-2343-48ad-9bf1-23a9b98bdacb"}}' |\
go run ./cmd/yggctl generate control-message --type command - |\
pub -broker tcp://test.mosquitto.org:1883 -topic yggdrasil/$(hostname)/control/in
```






