### PR TITLE
Enable CI builds

### DIFF
--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -1,0 +1,20 @@
+# This Makefile is part of a continuous development workflow integration with
+# Fedora's COPR build service (https://copr.fedorainfracloud.org). In order to
+# build an RPM in COPR's infrastructure, this Makefile exists to build a
+# SRPM. See https://docs.pagure.org/copr.copr/user_documentation.html#scm for
+# details on how this Makefile is expected to behave.
+#
+# N.B.: This Makefile should not be used to build an SRPM manually. Instead,
+# see 'dist/srpm' on how to use meson to build an SRPM manually.
+
+.PHONY: help
+help:
+	@echo "This Makefile is not intended to be run manually."
+	@echo "Run 'meson compile srpm' instead."
+
+.PHONY: srpm
+srpm:
+	dnf install --assumeyes bash-completion git go meson 'pkgconfig(dbus-1)' 'pkgconfig(systemd)' rpm-build
+	meson setup builddir -Dbuild_srpm=True -Dvendor=True -Dexamples=True
+	meson compile srpm -C builddir
+	mv builddir/dist/srpm/*.src.rpm $(outdir)

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -1,0 +1,45 @@
+name: Package
+
+on:
+  push:
+
+jobs:
+  build-srpm:
+    runs-on: ubuntu-latest
+    container: registry.fedoraproject.org/fedora:rawhide
+    steps:
+      - run: dnf install --assumeyes bash-completion git go meson 'pkgconfig(dbus-1)' rpm-build
+      - uses: actions/checkout@v3
+      - run: git config --system --add safe.directory $GITHUB_WORKSPACE
+      - run: meson setup $GITHUB_WORKSPACE/builddir -Dbuild_srpm=True
+      - run: meson compile srpm -C $GITHUB_WORKSPACE/builddir
+      - uses: actions/upload-artifact@v3
+        with:
+          name: yggdrasil-${{ github.sha }}
+          path: ${{ github.workspace }}/builddir/dist/srpm/*.src.rpm
+  build-rpm:
+    needs: build-srpm
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        registry:
+          - "registry.fedoraproject.org"
+        image:
+          - "fedora"
+        version:
+          - "rawhide"
+          - "latest"
+    container:
+      image: ${{ matrix.registry }}/${{ matrix.image }}:${{ matrix.version }}
+      options: "--privileged --cap-add=SYS_ADMIN"
+    steps:
+      - run: dnf install --assumeyes git mock
+      - uses: actions/download-artifact@v3
+        with:
+          name: yggdrasil-${{ github.sha }}
+      - run: mock --enable-network --rebuild --resultdir $GITHUB_WORKSPACE $GITHUB_WORKSPACE/*.src.rpm
+      - uses: actions/upload-artifact@v3
+        with:
+          name: yggdrasil-${{ matrix.image }}-${{ matrix.version }}
+          path: ${{ github.workspace }}/*.rpm

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -118,7 +118,13 @@ sudo go run ./cmd/yggd --config ./data/yggdrasil/config.toml
 
 Many default paths (such as Prefix, BinDir, LocalstateDir, etc), as well as some
 other compile-time constants, can be specified by providing a linker `-X` flag
-argument. See the `Makefile` or `constants.go` for a complete list. 
+argument. See the [meson built-in
+options](https://mesonbuild.com/Builtin-options.html) or
+`internal/constants/constants.go` for a complete list.
+
+It is also possible to compile `yggd` and all additional programs in this
+project into an RPM suitable for installation on Fedora-based distributions. See
+the README in `dist/srpm` for details.
 
 ## Debugging `yggd`
 

--- a/dist/meson.build
+++ b/dist/meson.build
@@ -1,0 +1,3 @@
+if get_option('build_srpm')
+  subdir('srpm')
+endif

--- a/dist/srpm/README.md
+++ b/dist/srpm/README.md
@@ -1,0 +1,19 @@
+This directory includes files necessary to build an SRPM as part of the normal
+`meson compile` step.
+
+# Usage
+
+1. Set the `build_srpm` build option to `True` when setting up the project:
+   `meson setup -Dbuild_srpm=True builddir`
+2. Compile the `srpm` target: `meson compile srpm -C builddir`
+
+An SRPM will be built and can be found in `builddir/dist/srpm`. This SRPM will
+need to be rebuilt into a binary in order to install it. To rebuild it using
+`mock` on Fedora, for example, run:
+
+```
+mock --rebuild ./builddir/dist/srpm/*.src.rpm
+```
+
+The RPM built by `mock` can be found (typically) in
+`/var/run/mock/<root-name>/results`.

--- a/dist/srpm/meson.build
+++ b/dist/srpm/meson.build
@@ -1,0 +1,45 @@
+git = find_program('git')
+rpmbuild = find_program('rpmbuild')
+tar = find_program('tar')
+bash = find_program('bash')
+
+commit = run_command(git, 'rev-parse', 'HEAD', capture: true, check: true).stdout().strip()
+
+if get_option('vendor')
+run_command([bash, files(meson.project_source_root() / 'build-aux' / 'vendor.sh')], check: true)
+endif
+
+build_root_basename = meson.project_build_root().split('/').get(-1)
+tarball = custom_target('tarball',
+  command: [
+    tar,
+    '--create',
+    '--gzip',
+    '--absolute-names',
+    '--file', '@OUTPUT@',
+    '--transform', 's+@0@+@1@-@2@+'.format(meson.project_source_root(), meson.project_name(), commit),
+    '--exclude', build_root_basename,
+    '--exclude', '.git',
+    '--exclude', '.vscode',
+    '--exclude', '.github',
+    '--exclude', '.copr',
+    meson.project_source_root()
+  ],
+  output: '@0@-@1@.tar.gz'.format(meson.project_name(), commit)
+)
+
+specfile = configure_file(
+  input: 'yggdrasil.spec.in',
+  output: '@BASENAME@',
+  configuration: {
+    'COMMIT': commit,
+    'VERSION': meson.project_version(),
+  }
+)
+
+run_target('srpm',
+  command: [rpmbuild, '-bs', '--define', 'commit @0@'.format(commit), '--define', '_srcrpmdir @0@'.format(meson.current_build_dir()), '--define', '_sourcedir @0@'.format(meson.current_build_dir()), specfile],
+  depends: [
+    tarball
+  ]
+)

--- a/dist/srpm/yggdrasil.spec.in
+++ b/dist/srpm/yggdrasil.spec.in
@@ -1,0 +1,107 @@
+# This RPM spec file exists primarily to enable CI/CD pipelines and automatic
+# testing of built RPMs. This RPM can be used as a suitable baseline for a
+# proper distribution package, but changes should be made to suit the needs of
+# the package.
+#
+# See https://src.fedoraproject.org/rpms/yggdrasil/blob/rawhide/f/yggdrasil.spec
+# for a better example of a downstream distribution packaging example.
+
+%bcond_without check
+
+# https://github.com/redhatinsights/yggdrasil
+%global goipath         github.com/redhatinsights/yggdrasil
+%global commit          @COMMIT@
+%global shortcommit     %(c=%{commit}; echo ${c:0:7})
+
+%if 0%{?fedora}
+%gometa -f
+%else
+%gometa
+%endif
+
+# Manually redefine %%dist to work around an issue in COPR where the build root
+# that creates the srpm does not define a value for %%dist. This should *NOT* be
+# carried in downstream; this is strictly an upstream/COPR/CI workaround.
+%if "%{dist}" == ""
+%global dist %{distprefix}.fc%{fedora}
+%endif
+
+%if 0%{?fedora}
+%global setup_flags -Dvendor=False -Dexamples=True
+%else
+%global setup_flags -Dvendor=True -Dexamples=True
+%endif
+
+%global common_description %{expand:
+yggdrasil is a system daemon that subscribes to topics on an MQTT broker and
+routes any data received on the topics to an appropriate child "worker" process,
+exchanging data with its worker processes through a D-Bus message broker.}
+
+%global golicenses      LICENSE
+%global godocs          CONTRIBUTING.md README.md
+
+Name:           yggdrasil
+Version:        @VERSION@
+Release:        0%{?dist}
+Summary:        Remote data transmission and processing client
+
+License:        GPL-3.0-only
+URL:            %{gourl}
+Source:         %{gosource}
+
+BuildRequires:  systemd-rpm-macros
+BuildRequires:  meson
+BuildRequires:  pkgconfig(dbus-1)
+BuildRequires:  pkgconfig(systemd)
+BuildRequires:  pkgconfig(bash-completion)
+
+%description %{common_description}
+
+%gopkg
+
+%prep
+%if 0%{?fedora}
+%goprep
+%else
+%goprep -k
+%endif
+
+%if 0%{?fedora}
+%generate_buildrequires
+%go_generate_buildrequires
+%endif
+
+%build
+%undefine _auto_set_build_flags
+export %gomodulesmode
+%{?gobuilddir:export GOPATH="%{gobuilddir}:${GOPATH:+${GOPATH}:}%{?gopath}"}
+%meson %setup_flags "-Dgobuildflags=[%(echo %{expand:%gocompilerflags} | sed -e s/"^"/"'"/ -e s/" "/"', '"/g -e s/"$"/"'"/), '-tags', '"rpm_crashtraceback\ ${BUILDTAGS:-}"', '-a', '-v', '-x']" -Dgoldflags='%{?currentgoldflags} -B 0x%(head -c20 /dev/urandom|od -An -tx1|tr -d " \n") -compressdwarf=false -linkmode=external -extldflags "%{build_ldflags} %{?__golang_extldflags}"'
+%meson_build
+
+%global gosupfiles ./ipc/com.redhat.Yggdrasil1.Dispatcher1.xml ./ipc/com.redhat.Yggdrasil1.Worker1.xml
+%install
+%meson_install
+%gopkginstall
+
+%if %{with check}
+%check
+%gocheck
+%endif
+
+%files
+%license LICENSE
+%doc CONTRIBUTING.md README.md
+%{_bindir}/*
+%{_libexecdir}/%{name}/*
+%config(noreplace) %{_sysconfdir}/%{name}
+%{_unitdir}/*
+%{_userunitdir}/*
+%{_datadir}/bash-completion/completions/*
+%{_datadir}/dbus-1/{interfaces,system-services,system.d}/*
+%{_datadir}/doc/%{name}/*
+%{_mandir}/man1/*
+
+%gopkgfiles
+
+%changelog
+%autochangelog

--- a/meson.build
+++ b/meson.build
@@ -37,6 +37,7 @@ subdir('cmd/yggd')
 subdir('data')
 subdir('dbus')
 subdir('doc')
+subdir('dist')
 subdir('ipc')
 
 if get_option('examples')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -4,3 +4,4 @@ option('vendor', type: 'boolean', value: false, description: 'Bundle go module d
 option('examples', type: 'boolean', value: false, description: 'Build and install the example workers')
 option('gobuildflags', type: 'array', value: ['-buildmode', 'pie'], description: 'Additional build flags to be passed to the Go compiler')
 option('goldflags', type: 'string', value: '', description: 'Additional linker flags to be passed to the Go compiler')
+option('build_srpm', type: 'boolean', value: false, description: 'Enable SRPM builds')


### PR DESCRIPTION
I added a 'dist' subdirectory, for distributions to maintain in-tree distribution compilation instructions. I added an 'srpm' subdirectory that uses meson's `run_target` to build an SRPM. The source tarball inserted into the SRPM is created from the *working* source root directory, including uncommitted changes. The resulting SRPM will include git version information in its "Release" field. The SRPM can be found in the meson build root, under the 'dist/srpm' directory.

Using that custom 'srpm' target, I added a `.copr/Makefile` that supports the COPR "make srpm" strategy to building packages. This enables the existing webhook to trigger [builds in COPR](https://copr.fedorainfracloud.org/coprs/linkdupont/yggdrasil/builds/).

Additionally, using that custom 'srpm' target, I added a GitHub Actions workflow that first builds the SRPM and uploads it as a build artifact. It then downloads that artifact and builds RPMs in containers (as of this writing, rawhide and Fedora 38).