### PR TITLE
feat: WIP: Added more debug logging to worker

### DIFF
--- a/cmd/yggctl/actions.go
+++ b/cmd/yggctl/actions.go
@@ -21,7 +21,14 @@ func generateDataMessageAction(c *cli.Context) error {
 		return cli.Exit(fmt.Errorf("cannot unmarshal metadata: %w", err), 1)
 	}
 
-	data, err := generateMessage("data", c.String("response-to"), c.String("directive"), c.Args().First(), metadata, c.Int("version"))
+	data, err := generateMessage(
+		"data",
+		c.String("response-to"),
+		c.String("directive"),
+		c.Args().First(),
+		metadata,
+		c.Int("version"),
+	)
 	if err != nil {
 		return cli.Exit(fmt.Errorf("cannot marshal message: %w", err), 1)
 	}
@@ -32,7 +39,14 @@ func generateDataMessageAction(c *cli.Context) error {
 }
 
 func generateControlMessageAction(c *cli.Context) error {
-	data, err := generateMessage(c.String("type"), c.String("response-to"), "", c.Args().First(), nil, c.Int("version"))
+	data, err := generateMessage(
+		c.String("type"),
+		c.String("response-to"),
+		"",
+		c.Args().First(),
+		nil,
+		c.Int("version"),
+	)
 	if err != nil {
 		return cli.Exit(fmt.Errorf("cannot marshal message: %w", err), 1)
 	}
@@ -182,7 +196,13 @@ func listenAction(ctx *cli.Context) error {
 func generateMessage(messageType, responseTo, directive, content string, metadata map[string]string, version int) ([]byte, error) {
 	switch messageType {
 	case "data":
-		msg, err := generateDataMessage(yggdrasil.MessageType(messageType), responseTo, directive, []byte(content), metadata, version)
+		msg, err := generateDataMessage(
+			yggdrasil.MessageType(messageType),
+			responseTo,
+			directive,
+			[]byte(content),
+			metadata,
+			version)
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/yggctl/generate.go
+++ b/cmd/yggctl/generate.go
@@ -9,7 +9,14 @@ import (
 	"github.com/redhatinsights/yggdrasil"
 )
 
-func generateDataMessage(messageType yggdrasil.MessageType, responseTo string, directive string, content []byte, metadata map[string]string, version int) (*yggdrasil.Data, error) {
+// generateDataMessage creates a data message of the appropriate type by
+func generateDataMessage(
+	messageType yggdrasil.MessageType,
+	responseTo string,
+	directive string,
+	content []byte,
+	metadata map[string]string,
+	version int) (*yggdrasil.Data, error) {
 	msg := yggdrasil.Data{
 		Type:       messageType,
 		MessageID:  uuid.New().String(),

--- a/cmd/yggd/client.go
+++ b/cmd/yggd/client.go
@@ -179,10 +179,14 @@ func (c *Client) Connect() error {
 		for e := range c.dispatcher.WorkerEvents {
 			args := []interface{}{e.Worker, e.Name}
 			switch e.Name {
+			// Only working event has a message
 			case ipc.WorkerEventNameWorking:
 				args = append(args, e.Message)
 			}
-			if err := c.conn.Emit("/com/redhat/Yggdrasil1", "com.redhat.Yggdrasil1.WorkerEvent", args...); err != nil {
+			if err := c.conn.Emit(
+				"/com/redhat/Yggdrasil1",
+				"com.redhat.Yggdrasil1.WorkerEvent",
+				args...); err != nil {
 				log.Errorf("cannot emit event: %v", err)
 				continue
 			}

--- a/ipc/com.redhat.Yggdrasil1.Worker1.xml
+++ b/ipc/com.redhat.Yggdrasil1.Worker1.xml
@@ -62,6 +62,12 @@
             3 = WORKING
             Emitted when the worker wishes to continue to announce it is
             working.
+
+            4 = CONNECTING
+            Emitted when the worker starts connecting to bus
+
+            5 = CONNECTED
+            Emitted when the worker is connected to bus
         -->
         <signal name="Event">
             <arg type="u" name="name" />

--- a/ipc/interfaces.go
+++ b/ipc/interfaces.go
@@ -12,13 +12,15 @@ var InterfaceDispatcher string
 type DispatcherEvent uint
 
 const (
-	// Emitted when the dispatcher receives the "disconnect" command.
+	// DispatcherEventReceivedDisconnect is emitted when the dispatcher receives
+	// the "disconnect" command.
 	DispatcherEventReceivedDisconnect DispatcherEvent = 1
 
-	// Emitted when the transport unexpected disconnects from the network.
+	// DispatcherEventUnexpectedDisconnect is emitted when the transport unexpected
+	// disconnects from the network.
 	DispatcherEventUnexpectedDisconnect DispatcherEvent = 2
 
-	// Emitted when the transport reconnects to the network.
+	// DispatcherEventConnectionRestored is emitted when the transport reconnects to the network.
 	DispatcherEventConnectionRestored DispatcherEvent = 3
 )
 
@@ -29,28 +31,39 @@ type WorkerEventName uint
 
 const (
 
-	// Emitted when the worker "accepts" a dispatched message and begins
-	// "working".
+	// WorkerEventNameBegin is emitted when the worker "accepts"
+	// a dispatched message and begins "working".
 	WorkerEventNameBegin WorkerEventName = 1
 
-	// Emitted when the worker finishes "working".
+	// WorkerEventNameEnd is emitted when the worker finishes "working".
 	WorkerEventNameEnd WorkerEventName = 2
 
-	// Emitted when the worker wishes to continue to announce it is
-	// working.
+	// WorkerEventNameWorking is emitted when the worker wishes to continue
+	// to announce it is working.
 	WorkerEventNameWorking WorkerEventName = 3
+
+	// WorkerEventNameConnecting is emitted when the worker starts connecting
+	WorkerEventNameConnecting WorkerEventName = 4
+
+	// WorkerEventNameConnected is emitted when the worker finishes connecting
+	WorkerEventNameConnected WorkerEventName = 5
 )
 
+// String returns textual representation of event name
 func (e WorkerEventName) String() string {
 	switch e {
-	case 1:
+	case WorkerEventNameBegin:
 		return "BEGIN"
-	case 2:
+	case WorkerEventNameEnd:
 		return "END"
-	case 3:
+	case WorkerEventNameWorking:
 		return "WORKING"
+	case WorkerEventNameConnecting:
+		return "CONNECTING"
+	case WorkerEventNameConnected:
+		return "CONNECTED"
 	}
-	return ""
+	return "UNKNOWN"
 }
 
 type WorkerEvent struct {

--- a/worker/echo/main.go
+++ b/worker/echo/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"github.com/google/uuid"
 	"os"
 	"os/signal"
 	"syscall"
@@ -19,8 +20,13 @@ var sleepTime time.Duration
 // echo opens a new dbus connection and calls the
 // com.redhat.Yggdrasil1.Dispatcher1.Transmit method, returning the metadata and
 // data it received.
-func echo(w *worker.Worker, addr string, id string, responseTo string, metadata map[string]string, data []byte) error {
-	if err := w.EmitEvent(ipc.WorkerEventNameWorking, fmt.Sprintf("echoing %v", data)); err != nil {
+func echo(
+	w *worker.Worker,
+	rcvAddr string,
+	rcvId string, responseTo string, metadata map[string]string, data []byte) error {
+
+	// Emit D-Bus signal to indicate that the worker is still working.
+	if err := w.EmitEvent(ipc.WorkerEventNameWorking, fmt.Sprintf("echoing %v", string(data))); err != nil {
 		return fmt.Errorf("cannot call EmitEvent: %w", err)
 	}
 
@@ -30,7 +36,23 @@ func echo(w *worker.Worker, addr string, id string, responseTo string, metadata 
 		time.Sleep(sleepTime)
 	}
 
-	responseCode, responseMetadata, responseData, err := w.Transmit(addr, id, responseTo, metadata, data)
+	// Set "response_to" according to the id of the message we received
+	echoResponseTo := rcvId
+	// Create new id for the message we are going to send
+	echoId := uuid.New().String()
+	// Create a new echo address, when remote content is enabled
+	echoAddr := ""
+	if w.RemoteContent {
+		if metadata["return_url"] != "" {
+			echoAddr = metadata["return_url"]
+		}
+	} else {
+		echoAddr = rcvAddr
+	}
+
+	log.Infof("echoing received message as (addr: %v, id: %v, responseTo: %s, metadata: %v, data: %v)",
+		rcvAddr, echoId, echoResponseTo, metadata, string(data))
+	responseCode, responseMetadata, responseData, err := w.Transmit(echoAddr, echoId, echoResponseTo, metadata, data)
 	if err != nil {
 		return fmt.Errorf("cannot call Transmit: %w", err)
 	}
@@ -40,6 +62,7 @@ func echo(w *worker.Worker, addr string, id string, responseTo string, metadata 
 	log.Infof("responseMetadata = %#v", responseMetadata)
 	log.Infof("responseData = %v", responseData)
 
+	// Set the DispatchedAt D-Bus property to the current time.
 	if err := w.SetFeature("DispatchedAt", time.Now().Format(time.RFC3339)); err != nil {
 		return fmt.Errorf("cannot set feature: %w", err)
 	}
@@ -65,13 +88,31 @@ func main() {
 	flag.DurationVar(&sleepTime, "sleep", 0, "sleep time in seconds before echoing the response")
 	flag.Parse()
 
+	// Set up logging.
 	level, err := log.ParseLevel(logLevel)
 	if err != nil {
 		log.Fatalf("error: cannot parse log level: %v", err)
 	}
 	log.SetLevel(level)
+	log.SetPrefix(fmt.Sprintf("[%v] ", os.Args[0]))
+	if log.CurrentLevel() >= log.LevelDebug {
+		log.SetFlags(log.LstdFlags | log.Llongfile)
+	}
 
-	w, err := worker.NewWorker("echo", remoteContent, map[string]string{"DispatchedAt": "", "Version": "1"}, echo, events)
+	// Show information about worker type.
+	if remoteContent {
+		log.Infof("connecting as a remote content worker")
+	} else {
+		log.Infof("connecting as a normal worker")
+	}
+
+	w, err := worker.NewWorker(
+		"echo",
+		remoteContent,
+		map[string]string{"DispatchedAt": "", "Version": "1"},
+		echo,
+		events,
+	)
 	if err != nil {
 		log.Fatalf("error: cannot create worker: %v", err)
 	}
@@ -81,7 +122,10 @@ func main() {
 	quit := make(chan os.Signal, 1)
 	signal.Notify(quit, syscall.SIGTERM, syscall.SIGINT)
 
+	// Connect to the D-Bus bus and start listening for messages
 	if err := w.Connect(quit); err != nil {
 		log.Fatalf("error: cannot connect: %v", err)
 	}
+
+	log.Debug("finished")
 }


### PR DESCRIPTION
* Consider this as WIP, because I did many changes
  in this commit that needs more discussion.
* Added more debug logging messages to worker code
* Wrapped long lines
* Added more comments
* Modified little bit example of echo worker and
  populate id and response_to fields properly
* Added two more events "CONNECTING" and "CONNECTED"
  to show some progress, when worker is starting.
  Without that you cannot see if worker is actually
  "talking" with yggd during start of the worker
  process.
* Fixed code for the case, when worker is started
  in "RemoteContent" mode. Without that it is not
  possible to get response from the HTTP server.
* Tried to fix example worker (echo worker) for the
  case, when it is started with -remote-content CLI
  option. The echo worker tries to use "return_url"
  metadata as a address for w.Transmit().