### PR TITLE
fix: Remove debug and trace logs that print msg

### DIFF
--- a/cmd/yggd/grpc.go
+++ b/cmd/yggd/grpc.go
@@ -105,7 +105,6 @@ func (d *dispatcher) Send(ctx context.Context, r *pb.Data) (*pb.Receipt, error) 
 		}
 	}
 	log.Debugf("received message %v", data.MessageID)
-	log.Tracef("message: %+v", data.Content)
 
 	return &pb.Receipt{}, nil
 }
@@ -166,7 +165,6 @@ func (d *dispatcher) sendData() {
 			_, err = c.Send(ctx, &msg)
 			if err != nil {
 				log.Errorf("cannot send message %v: %v", data.MessageID, err)
-				log.Tracef("message: %+v", data)
 				return
 			}
 			log.Debugf("dispatched message %v to worker %v", msg.MessageId, data.Directive)

--- a/cmd/yggd/http.go
+++ b/cmd/yggd/http.go
@@ -48,7 +48,7 @@ func get(url string) ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("cannot read response body: %w", err)
 	}
-	log.Debugf("received HTTP %v: %v", resp.Status, strings.TrimSpace(string(data)))
+	log.Debugf("received HTTP %v", resp.Status)
 
 	if resp.StatusCode >= 400 {
 		return nil, &yggdrasil.APIResponseError{Code: resp.StatusCode, Body: strings.TrimSpace(string(data))}
@@ -81,7 +81,7 @@ func post(url string, headers map[string]string, body []byte) error {
 	if err != nil {
 		return fmt.Errorf("cannot read response body: %w", err)
 	}
-	log.Debugf("received HTTP %v: %v", resp.Status, strings.TrimSpace(string(data)))
+	log.Debugf("received HTTP %v", resp.Status)
 
 	if resp.StatusCode >= 400 {
 		return &yggdrasil.APIResponseError{Code: resp.StatusCode, Body: strings.TrimSpace(string(data))}

--- a/cmd/yggd/mqtt.go
+++ b/cmd/yggd/mqtt.go
@@ -22,7 +22,7 @@ func handleDataMessage(client mqtt.Client, msg mqtt.Message, sendQ chan<- yggdra
 		log.Errorf("cannot unmarshal data message: %v", err)
 		return
 	}
-	log.Tracef("message: %+v", data)
+	log.Tracef("message: %v", data.MessageID)
 
 	sendQ <- data
 }
@@ -129,7 +129,6 @@ func publishConnectionStatus(c mqtt.Client, dispatchers map[string]map[string]st
 		log.Errorf("failed to publish message: %v", token.Error())
 	}
 	log.Debugf("published message %v to topic %v", msg.MessageID, topic)
-	log.Tracef("message: %+v", msg)
 }
 
 func publishReceivedData(client mqtt.Client, c <-chan yggdrasil.Data) {
@@ -146,6 +145,5 @@ func publishReceivedData(client mqtt.Client, c <-chan yggdrasil.Data) {
 			log.Errorf("failed to publish message: %v", token.Error())
 		}
 		log.Debugf("published message %v to topic %v", d.MessageID, topic)
-		log.Tracef("message: %+v", d)
 	}
 }


### PR DESCRIPTION
Some debug and trace logs were printing message content after being downloaded by the DetachedContent option.

This commit removes some of those logs that will prevent important information being leaked.