### PR TITLE
feat: Remove debug and trace content log

### DIFF
--- a/internal/transport/http.go
+++ b/internal/transport/http.go
@@ -151,7 +151,6 @@ func (t *HTTP) Tx(addr string, metadata map[string]string, data []byte) (respons
 	headers := map[string]string{
 		"Content-Type": "application/json",
 	}
-	log.Tracef("posting HTTP request body: %s", string(data))
 	resp, err := t.client.Post(url, headers, data)
 	if err != nil && resp == nil {
 		return TxResponseErr, nil, nil, fmt.Errorf("cannot perform HTTP request: %w", err)

--- a/internal/transport/mqtt.go
+++ b/internal/transport/mqtt.go
@@ -172,7 +172,6 @@ func (t *MQTT) Tx(addr string, metadata map[string]string, data []byte) (respons
 		return TxResponseErr, nil, nil, token.Error()
 	}
 	log.Debugf("published message to topic %v", topic)
-	log.Tracef("message: %v", string(data))
 
 	return TxResponseOK, map[string]string{}, []byte{}, nil
 }


### PR DESCRIPTION
Some debug and trace logs were printing message content after being downloaded by the DetachedContent option.

This commit removes some of those logs that will prevent important information being leaked.