### PR TITLE
feat: add MQTT connection options

### DIFF
--- a/cmd/yggd/main.go
+++ b/cmd/yggd/main.go
@@ -109,6 +109,24 @@ func main() {
 			Usage:  "Wait for `DURATION` before cancelling an HTTP request",
 			Hidden: true,
 		}),
+		altsrc.NewBoolFlag(&cli.BoolFlag{
+			Name:   config.FlagNameMQTTConnectRetry,
+			Usage:  "Enable automatic reconnection logic when the client initially connects",
+			Value:  false,
+			Hidden: true,
+		}),
+		altsrc.NewDurationFlag(&cli.DurationFlag{
+			Name:   config.FlagNameMQTTConnectRetryInterval,
+			Usage:  "Sets the time to wait between connection attempts to `DURATION`",
+			Value:  30 * time.Second,
+			Hidden: true,
+		}),
+		altsrc.NewBoolFlag(&cli.BoolFlag{
+			Name:   config.FlagNameMQTTAutoReconnect,
+			Usage:  "Enable automatic reconnection when the client disconnects",
+			Value:  true,
+			Hidden: true,
+		}),
 	}
 
 	// This BeforeFunc will load flag values from a config file only if the

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -12,18 +12,21 @@ import (
 )
 
 const (
-	FlagNameLogLevel       = "log-level"
-	FlagNameCertFile       = "cert-file"
-	FlagNameKeyFile        = "key-file"
-	FlagNameCaRoot         = "ca-root"
-	FlagNameServer         = "server"
-	FlagNameClientID       = "client-id"
-	FlagNamePathPrefix     = "path-prefix"
-	FlagNameProtocol       = "protocol"
-	FlagNameDataHost       = "data-host"
-	FlagNameCanonicalFacts = "canonical-facts"
-	FlagNameHTTPRetries    = "http-retries"
-	FlagNameHTTPTimeout    = "http-timeout"
+	FlagNameLogLevel                 = "log-level"
+	FlagNameCertFile                 = "cert-file"
+	FlagNameKeyFile                  = "key-file"
+	FlagNameCaRoot                   = "ca-root"
+	FlagNameServer                   = "server"
+	FlagNameClientID                 = "client-id"
+	FlagNamePathPrefix               = "path-prefix"
+	FlagNameProtocol                 = "protocol"
+	FlagNameDataHost                 = "data-host"
+	FlagNameCanonicalFacts           = "canonical-facts"
+	FlagNameHTTPRetries              = "http-retries"
+	FlagNameHTTPTimeout              = "http-timeout"
+	FlagNameMQTTConnectRetry         = "mqtt-connect-retry"
+	FlagNameMQTTConnectRetryInterval = "mqtt-connect-retry-interval"
+	FlagNameMQTTAutoReconnect        = "mqtt-auto-reconnect"
 )
 
 var DefaultConfig = Config{
@@ -76,6 +79,18 @@ type Config struct {
 	// HTTPTimeout is the duration the client will wait before cancelling an
 	// HTTP request.
 	HTTPTimeout time.Duration
+
+	// MQTTConnectRetry is the MQTT client option to enable connection retry
+	// logic when performing the initial connection.
+	MQTTConnectRetry bool
+
+	// MQTTConnectRetryInterval is the MQTT client option that specifies the
+	// duration to wait between connection retry attempts.
+	MQTTConnectRetryInterval time.Duration
+
+	// MQTTAutoReconnect is the MQTT client option that enables automatic
+	// reconnection logic when the client unexpectedly disconnects.
+	MQTTAutoReconnect bool
 }
 
 func (conf *Config) CreateTLSConfig() (*tls.Config, error) {

--- a/internal/transport/mqtt.go
+++ b/internal/transport/mqtt.go
@@ -43,6 +43,9 @@ func NewMQTTTransport(clientID string, brokers []string, tlsConfig *tls.Config) 
 	opts.SetClientID(clientID)
 	opts.SetTLSConfig(tlsConfig.Clone())
 	opts.SetCleanSession(true)
+	opts.SetConnectRetry(config.DefaultConfig.MQTTConnectRetry)
+	opts.SetConnectRetryInterval(config.DefaultConfig.MQTTConnectRetryInterval)
+	opts.SetAutoReconnect(config.DefaultConfig.MQTTAutoReconnect)
 	opts.SetOnConnectHandler(func(c mqtt.Client) {
 		t.events <- TransporterEventConnected
 


### PR DESCRIPTION
Add three options to adjust MQTT client configuration:

    mqtt-connect-retry
    mqtt-connect-retry-interval
    mqtt-auto-reconnect

We are exposing these options as hidden configurable values in the hope that we can identify a cause for some unknown client disconnections.