### PR TITLE
feat: reworked optional data sent in emitted events

### DIFF
--- a/cmd/yggctl/actions.go
+++ b/cmd/yggctl/actions.go
@@ -193,14 +193,14 @@ func listenAction(ctx *cli.Context) error {
 			if !ok {
 				return cli.Exit(fmt.Errorf("cannot cast %T as string", s.Body[2]), 1)
 			}
-			var message string
+			var data map[string]string
 			if len(s.Body) > 3 {
-				message, ok = s.Body[3].(string)
+				data, ok = s.Body[3].(map[string]string)
 				if !ok {
-					return cli.Exit(fmt.Errorf("cannot cast %T as string", s.Body[3]), 1)
+					return cli.Exit(fmt.Errorf("cannot cast %T as map[string]string", s.Body[3]), 1)
 				}
 			}
-			log.Printf("%v: %v: %v: %v", worker, messageID, ipc.WorkerEventName(name), message)
+			log.Printf("%v: %v: %v: %v", worker, messageID, ipc.WorkerEventName(name), data)
 
 		}
 	}

--- a/cmd/yggctl/actions.go
+++ b/cmd/yggctl/actions.go
@@ -193,15 +193,25 @@ func listenAction(ctx *cli.Context) error {
 			if !ok {
 				return cli.Exit(fmt.Errorf("cannot cast %T as string", s.Body[2]), 1)
 			}
-			var data map[string]string
+			data := map[string]string{}
 			if len(s.Body) > 3 {
 				data, ok = s.Body[3].(map[string]string)
 				if !ok {
 					return cli.Exit(fmt.Errorf("cannot cast %T as map[string]string", s.Body[3]), 1)
 				}
 			}
-			log.Printf("%v: %v: %v: %v", worker, messageID, ipc.WorkerEventName(name), data)
+			parsedData, err := json.Marshal(data)
+			if err != nil {
+				return cli.Exit(fmt.Errorf("unable to parse optional data: %v", data), 1)
+			}
 
+			log.Printf(
+				"%v: %v: %v: %v",
+				worker,
+				messageID,
+				ipc.WorkerEventName(name),
+				string(parsedData),
+			)
 		}
 	}
 	return nil

--- a/cmd/yggd/client.go
+++ b/cmd/yggd/client.go
@@ -182,7 +182,7 @@ func (c *Client) Connect() error {
 			args := []interface{}{e.Worker, e.Name, e.MessageID}
 			switch e.Name {
 			case ipc.WorkerEventNameWorking:
-				args = append(args, e.Message)
+				args = append(args, e.Data)
 			}
 			if err := c.conn.Emit("/com/redhat/Yggdrasil1", "com.redhat.Yggdrasil1.WorkerEvent", args...); err != nil {
 				log.Errorf("cannot emit event: %v", err)

--- a/dbus/com.redhat.Yggdrasil1.xml
+++ b/dbus/com.redhat.Yggdrasil1.xml
@@ -40,7 +40,7 @@
             @worker: Name of the worker emitting the event.
             @name: Name of the event.
             @message_id: The id associated with the worker message.
-            @message: Optional message included with the event.
+            @data: Key-value pairs of optional data provided with the event.
 
             Emitted by a worker when certain conditions arise, such as beginning
             or ending work.
@@ -62,7 +62,7 @@
             <arg type="s" name="worker" />
             <arg type="u" name="name" />
             <arg type="s" name="message_id" />
-            <arg type="s" name="message" />
+            <arg type="a{ss}" name="data" />
         </signal>
     </interface>
 </node>

--- a/internal/work/dispatcher.go
+++ b/internal/work/dispatcher.go
@@ -396,11 +396,11 @@ func workerEventFromSignal(s *dbus.Signal) (*ipc.WorkerEvent, error) {
 			}
 			event.MessageID = messageID
 		case 2:
-			message, ok := v.(string)
+			data, ok := v.(map[string]string)
 			if !ok {
-				return nil, newStringTypeConversionError(v)
+				return nil, newStringMapTypeConversionError(v)
 			}
-			event.Message = message
+			event.Data = data
 		}
 	}
 

--- a/internal/work/dispatcher_test.go
+++ b/internal/work/dispatcher_test.go
@@ -52,13 +52,13 @@ func TestWorkerEventFromSignal(t *testing.T) {
 				Body: []interface{}{
 					uint32(3),
 					"6925055f-167a-45cc-9869-1789ee37883f",
-					"working message",
+					map[string]string{"message": "working message"},
 				},
 			},
 			want: &ipc.WorkerEvent{
 				Name:      ipc.WorkerEventNameWorking,
 				MessageID: "6925055f-167a-45cc-9869-1789ee37883f",
-				Message:   "working message",
+				Data:      map[string]string{"message": "working message"},
 			},
 		},
 		{
@@ -83,7 +83,7 @@ func TestWorkerEventFromSignal(t *testing.T) {
 				Body: []interface{}{uint32(3), "6925055f-167a-45cc-9869-1789ee37883f", 3},
 			},
 			want:      nil,
-			wantError: newStringTypeConversionError(3),
+			wantError: newStringMapTypeConversionError(3),
 		},
 	}
 

--- a/internal/work/errors.go
+++ b/internal/work/errors.go
@@ -26,3 +26,10 @@ func newStringTypeConversionError(parameter interface{}) typeConversionError {
 		t: reflect.TypeOf(""),
 	}
 }
+
+func newStringMapTypeConversionError(parameter interface{}) typeConversionError {
+	return typeConversionError{
+		p: reflect.ValueOf(parameter),
+		t: reflect.TypeOf(map[string]string{}),
+	}
+}

--- a/ipc/com.redhat.Yggdrasil1.Worker1.xml
+++ b/ipc/com.redhat.Yggdrasil1.Worker1.xml
@@ -46,7 +46,7 @@
             Event:
             @name: Name of the event.
             @message_id: The id associated with the worker message.
-            @message: Optional message included with the event.
+            @data: Key-value pairs of optional data provided with the event.
 
             Emitted by a worker when certain conditions arise, such as beginning
             or ending work.
@@ -67,7 +67,7 @@
         <signal name="Event">
             <arg type="u" name="name" />
             <arg type="s" name="message_id" />
-            <arg type="s" name="message" />
+            <arg type="a{ss}" name="data" />
         </signal>
     </interface>
 

--- a/ipc/interfaces.go
+++ b/ipc/interfaces.go
@@ -57,5 +57,5 @@ type WorkerEvent struct {
 	Worker    string
 	Name      WorkerEventName
 	MessageID string
-	Message   string
+	Data      map[string]string
 }

--- a/worker/echo/main.go
+++ b/worker/echo/main.go
@@ -30,7 +30,11 @@ func echo(
 	metadata map[string]string,
 	data []byte,
 ) error {
-	if err := w.EmitEvent(ipc.WorkerEventNameWorking, rcvId, fmt.Sprintf("echoing %v", data)); err != nil {
+	if err := w.EmitEvent(
+		ipc.WorkerEventNameWorking,
+		rcvId,
+		map[string]string{"message": fmt.Sprintf("echoing %v", data)},
+	); err != nil {
 		return fmt.Errorf("cannot call EmitEvent: %w", err)
 	}
 

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -176,11 +176,16 @@ func (w *Worker) Transmit(
 	return
 }
 
-// EmitEvent emits a WorkerEvent, worker message id, and an optional message.
-func (w *Worker) EmitEvent(event ipc.WorkerEventName, messageID string, message string) error {
-	args := []interface{}{event, messageID}
-	if message != "" {
-		args = append(args, message)
+// EmitEvent emits a WorkerEvent, worker message id, and key-value pairs of optional data.
+func (w *Worker) EmitEvent(
+	event ipc.WorkerEventName,
+	messageID string,
+	data map[string]string,
+) error {
+	args := []interface{}{
+		event,
+		messageID,
+		data,
 	}
 	log.Debugf("emitting event %v", event)
 	return w.conn.Emit(
@@ -205,7 +210,7 @@ func (w *Worker) dispatch(
 	log.Tracef("metadata = %#v", metadata)
 	log.Tracef("data = %v", data)
 
-	if err := w.EmitEvent(ipc.WorkerEventNameBegin, id, ""); err != nil {
+	if err := w.EmitEvent(ipc.WorkerEventNameBegin, id, map[string]string{}); err != nil {
 		return dbus.NewError("com.redhat.Yggdrasil1.Worker1.EventError", []interface{}{err.Error()})
 	}
 
@@ -213,7 +218,7 @@ func (w *Worker) dispatch(
 		if err := w.rx(w, addr, id, responseTo, metadata, data); err != nil {
 			log.Errorf("cannot call rx: %v", err)
 		}
-		if err := w.EmitEvent(ipc.WorkerEventNameEnd, id, ""); err != nil {
+		if err := w.EmitEvent(ipc.WorkerEventNameEnd, id, map[string]string{}); err != nil {
 			log.Errorf("cannot emit event: %v", err)
 		}
 	}()


### PR DESCRIPTION
This commit is proposing a change in how optional data is sent in emitted events
and parsed in the yggdrasil dispatcher to simplify the process if additional optional
data needs to be included in emitted worker events in the future.
This update should also not show any changes in behaviour compared to the main branch.

This work primarily came out of attempts to add a `responseTo` optional field in the emitted event
while avoiding parsing complications in the dispatcher. [#141]