### PR TITLE
feat: added "responseTo" field in worker emitted events

### DIFF
--- a/cmd/yggctl/actions.go
+++ b/cmd/yggctl/actions.go
@@ -193,11 +193,15 @@ func listenAction(ctx *cli.Context) error {
 			if !ok {
 				return cli.Exit(fmt.Errorf("cannot cast %T as string", s.Body[2]), 1)
 			}
+			responseTo, ok := s.Body[3].(string)
+			if !ok {
+				return cli.Exit(fmt.Errorf("cannot cast %T as string", s.Body[3]), 1)
+			}
 			data := map[string]string{}
-			if len(s.Body) > 3 {
-				data, ok = s.Body[3].(map[string]string)
+			if len(s.Body) > 4 {
+				data, ok = s.Body[4].(map[string]string)
 				if !ok {
-					return cli.Exit(fmt.Errorf("cannot cast %T as map[string]string", s.Body[3]), 1)
+					return cli.Exit(fmt.Errorf("cannot cast %T as map[string]string", s.Body[4]), 1)
 				}
 			}
 			parsedData, err := json.Marshal(data)
@@ -206,10 +210,11 @@ func listenAction(ctx *cli.Context) error {
 			}
 
 			log.Printf(
-				"%v: %v: %v: %v",
+				"%v: %v: %v: %v: %v",
 				worker,
 				messageID,
 				ipc.WorkerEventName(name),
+				responseTo,
 				string(parsedData),
 			)
 		}

--- a/cmd/yggd/client.go
+++ b/cmd/yggd/client.go
@@ -179,7 +179,7 @@ func (c *Client) Connect() error {
 	// channel, emitting a D-Bus "WorkerEvent" signal for each.
 	go func() {
 		for e := range c.dispatcher.WorkerEvents {
-			args := []interface{}{e.Worker, e.Name, e.MessageID}
+			args := []interface{}{e.Worker, e.Name, e.MessageID, e.ResponseTo}
 			switch e.Name {
 			case ipc.WorkerEventNameWorking:
 				args = append(args, e.Data)

--- a/dbus/com.redhat.Yggdrasil1.xml
+++ b/dbus/com.redhat.Yggdrasil1.xml
@@ -40,6 +40,7 @@
             @worker: Name of the worker emitting the event.
             @name: Name of the event.
             @message_id: The id associated with the worker message.
+            @response_to: Unique ID of the message this message is in reply to.
             @data: Key-value pairs of optional data provided with the event.
 
             Emitted by a worker when certain conditions arise, such as beginning
@@ -62,6 +63,7 @@
             <arg type="s" name="worker" />
             <arg type="u" name="name" />
             <arg type="s" name="message_id" />
+            <arg type="s" name="response_to" />
             <arg type="a{ss}" name="data" />
         </signal>
     </interface>

--- a/internal/work/dispatcher.go
+++ b/internal/work/dispatcher.go
@@ -396,6 +396,12 @@ func workerEventFromSignal(s *dbus.Signal) (*ipc.WorkerEvent, error) {
 			}
 			event.MessageID = messageID
 		case 2:
+			responseTo, ok := v.(string)
+			if !ok {
+				return nil, newStringTypeConversionError(v)
+			}
+			event.ResponseTo = responseTo
+		case 3:
 			data, ok := v.(map[string]string)
 			if !ok {
 				return nil, newStringMapTypeConversionError(v)

--- a/internal/work/dispatcher_test.go
+++ b/internal/work/dispatcher_test.go
@@ -19,31 +19,31 @@ func TestWorkerEventFromSignal(t *testing.T) {
 		{
 			input: &dbus.Signal{
 				Name: "com.redhat.Yggdrasil1.Worker1.Event",
-				Body: []interface{}{uint32(1), "6925055f-167a-45cc-9869-1789ee37883f"},
+				Body: []interface{}{
+					uint32(1),
+					"6925055f-167a-45cc-9869-1789ee37883f",
+					"123456f-167a-45cc-9869-1789ee37883f",
+				},
 			},
 			want: &ipc.WorkerEvent{
-				Name:      ipc.WorkerEventNameBegin,
-				MessageID: "6925055f-167a-45cc-9869-1789ee37883f",
+				Name:       ipc.WorkerEventNameBegin,
+				MessageID:  "6925055f-167a-45cc-9869-1789ee37883f",
+				ResponseTo: "123456f-167a-45cc-9869-1789ee37883f",
 			},
 		},
 		{
 			input: &dbus.Signal{
 				Name: "com.redhat.Yggdrasil1.Worker1.Event",
-				Body: []interface{}{uint32(2), "6925055f-167a-45cc-9869-1789ee37883f"},
+				Body: []interface{}{
+					uint32(2),
+					"6925055f-167a-45cc-9869-1789ee37883f",
+					"123456f-167a-45cc-9869-1789ee37883f",
+				},
 			},
 			want: &ipc.WorkerEvent{
-				Name:      ipc.WorkerEventNameEnd,
-				MessageID: "6925055f-167a-45cc-9869-1789ee37883f",
-			},
-		},
-		{
-			input: &dbus.Signal{
-				Name: "com.redhat.Yggdrasil1.Worker1.Event",
-				Body: []interface{}{uint32(3), "6925055f-167a-45cc-9869-1789ee37883f"},
-			},
-			want: &ipc.WorkerEvent{
-				Name:      ipc.WorkerEventNameWorking,
-				MessageID: "6925055f-167a-45cc-9869-1789ee37883f",
+				Name:       ipc.WorkerEventNameEnd,
+				MessageID:  "6925055f-167a-45cc-9869-1789ee37883f",
+				ResponseTo: "123456f-167a-45cc-9869-1789ee37883f",
 			},
 		},
 		{
@@ -52,13 +52,30 @@ func TestWorkerEventFromSignal(t *testing.T) {
 				Body: []interface{}{
 					uint32(3),
 					"6925055f-167a-45cc-9869-1789ee37883f",
+					"123456f-167a-45cc-9869-1789ee37883f",
+				},
+			},
+			want: &ipc.WorkerEvent{
+				Name:       ipc.WorkerEventNameWorking,
+				MessageID:  "6925055f-167a-45cc-9869-1789ee37883f",
+				ResponseTo: "123456f-167a-45cc-9869-1789ee37883f",
+			},
+		},
+		{
+			input: &dbus.Signal{
+				Name: "com.redhat.Yggdrasil1.Worker1.Event",
+				Body: []interface{}{
+					uint32(3),
+					"6925055f-167a-45cc-9869-1789ee37883f",
+					"123456f-167a-45cc-9869-1789ee37883f",
 					map[string]string{"message": "working message"},
 				},
 			},
 			want: &ipc.WorkerEvent{
-				Name:      ipc.WorkerEventNameWorking,
-				MessageID: "6925055f-167a-45cc-9869-1789ee37883f",
-				Data:      map[string]string{"message": "working message"},
+				Name:       ipc.WorkerEventNameWorking,
+				MessageID:  "6925055f-167a-45cc-9869-1789ee37883f",
+				ResponseTo: "123456f-167a-45cc-9869-1789ee37883f",
+				Data:       map[string]string{"message": "working message"},
 			},
 		},
 		{
@@ -80,7 +97,20 @@ func TestWorkerEventFromSignal(t *testing.T) {
 		{
 			input: &dbus.Signal{
 				Name: "com.redhat.Yggdrasil1.Worker1.Event",
-				Body: []interface{}{uint32(3), "6925055f-167a-45cc-9869-1789ee37883f", 3},
+				Body: []interface{}{uint32(1), "6925055f-167a-45cc-9869-1789ee37883f", 3},
+			},
+			want:      nil,
+			wantError: newStringTypeConversionError(3),
+		},
+		{
+			input: &dbus.Signal{
+				Name: "com.redhat.Yggdrasil1.Worker1.Event",
+				Body: []interface{}{
+					uint32(3),
+					"6925055f-167a-45cc-9869-1789ee37883f",
+					"6925055f-167a-45cc-9869-1789ee37883f",
+					3,
+				},
 			},
 			want:      nil,
 			wantError: newStringMapTypeConversionError(3),

--- a/ipc/com.redhat.Yggdrasil1.Worker1.xml
+++ b/ipc/com.redhat.Yggdrasil1.Worker1.xml
@@ -46,6 +46,7 @@
             Event:
             @name: Name of the event.
             @message_id: The id associated with the worker message.
+            @response_to: Unique ID of the message this message is in reply to.
             @data: Key-value pairs of optional data provided with the event.
 
             Emitted by a worker when certain conditions arise, such as beginning
@@ -67,6 +68,7 @@
         <signal name="Event">
             <arg type="u" name="name" />
             <arg type="s" name="message_id" />
+            <arg type="s" name="response_to" />
             <arg type="a{ss}" name="data" />
         </signal>
     </interface>

--- a/ipc/interfaces.go
+++ b/ipc/interfaces.go
@@ -54,8 +54,9 @@ func (e WorkerEventName) String() string {
 }
 
 type WorkerEvent struct {
-	Worker    string
-	Name      WorkerEventName
-	MessageID string
-	Data      map[string]string
+	Worker     string
+	Name       WorkerEventName
+	MessageID  string
+	ResponseTo string
+	Data       map[string]string
 }

--- a/worker/echo/main.go
+++ b/worker/echo/main.go
@@ -34,6 +34,7 @@ func echo(
 	if err := w.EmitEvent(
 		ipc.WorkerEventNameWorking,
 		rcvId,
+		responseTo,
 		map[string]string{"message": fmt.Sprintf("echoing %v", data)},
 	); err != nil {
 		return fmt.Errorf("cannot call EmitEvent: %w", err)

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -180,11 +180,13 @@ func (w *Worker) Transmit(
 func (w *Worker) EmitEvent(
 	event ipc.WorkerEventName,
 	messageID string,
+	responseTo string,
 	data map[string]string,
 ) error {
 	args := []interface{}{
 		event,
 		messageID,
+		responseTo,
 		data,
 	}
 	log.Debugf("emitting event %v", event)
@@ -210,7 +212,7 @@ func (w *Worker) dispatch(
 	log.Tracef("metadata = %#v", metadata)
 	log.Tracef("data = %v", data)
 
-	if err := w.EmitEvent(ipc.WorkerEventNameBegin, id, map[string]string{}); err != nil {
+	if err := w.EmitEvent(ipc.WorkerEventNameBegin, id, responseTo, map[string]string{}); err != nil {
 		return dbus.NewError("com.redhat.Yggdrasil1.Worker1.EventError", []interface{}{err.Error()})
 	}
 
@@ -218,7 +220,7 @@ func (w *Worker) dispatch(
 		if err := w.rx(w, addr, id, responseTo, metadata, data); err != nil {
 			log.Errorf("cannot call rx: %v", err)
 		}
-		if err := w.EmitEvent(ipc.WorkerEventNameEnd, id, map[string]string{}); err != nil {
+		if err := w.EmitEvent(ipc.WorkerEventNameEnd, id, responseTo, map[string]string{}); err != nil {
 			log.Errorf("cannot emit event: %v", err)
 		}
 	}()


### PR DESCRIPTION
Currently uses cherry-picked commits from dependent PR: #140 which needs to be removed when the dependent PR gets approved and merged.