### PR TITLE
fix(ci): golangci-lint timing out in large PRs

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -34,8 +34,8 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v3.3.0
         with:
-          version: "latest"
-          args: "--verbose"
+          version: latest
+          args: --verbose --timeout=3m
   lint-language:
     name: Lint language
     runs-on: ubuntu-latest


### PR DESCRIPTION
golangci-lint CI actions are failing due to the lower default timeout (1m), and this commit
updates the yaml to include a 3m timeout: `--timeout=3m`

This should resolve CI issues popping up in: https://github.com/RedHatInsights/yggdrasil/pull/116