### PR TITLE
Add 'noop' transport

### DIFF
--- a/cmd/yggd/main.go
+++ b/cmd/yggd/main.go
@@ -140,6 +140,16 @@ func setupClient(
 		if err != nil {
 			return nil, nil, cli.Exit(fmt.Errorf("cannot create HTTP transport: %w", err), 1)
 		}
+	case "none":
+		var err error
+		transporter, err = transport.NewNoopTransport()
+		if err != nil {
+			return nil, nil, cli.Exit(fmt.Errorf("cannot create no-op transport: %w", err), 1)
+		}
+		log.Info("no network protocol specified - no data will be sent or received over the network")
+		for _, server := range config.DefaultConfig.Server {
+			log.Warnf("no network protocol specified - ignoring server option '%v'", server)
+		}
 	default:
 		return nil, nil, cli.Exit(
 			fmt.Errorf("unsupported transport protocol: %v", config.DefaultConfig.Protocol),
@@ -436,7 +446,7 @@ func main() {
 		}),
 		altsrc.NewStringFlag(&cli.StringFlag{
 			Name:  config.FlagNameProtocol,
-			Usage: "Transmit data remotely using `PROTOCOL` ('mqtt' or 'http')",
+			Usage: "Transmit data remotely using `PROTOCOL` ('mqtt', 'http' or 'none')",
 			Value: "mqtt",
 		}),
 		altsrc.NewStringSliceFlag(&cli.StringSliceFlag{

--- a/dist/srpm/yggdrasil.spec.in
+++ b/dist/srpm/yggdrasil.spec.in
@@ -102,6 +102,3 @@ export %gomodulesmode
 %{_mandir}/man1/*
 
 %gopkgfiles
-
-%changelog
-%autochangelog

--- a/internal/transport/noop.go
+++ b/internal/transport/noop.go
@@ -1,0 +1,33 @@
+package transport
+
+import "crypto/tls"
+
+// Noop is a Transporter that does nothing. This Transport is used to enable a
+// "local only" dispatch mode.
+type Noop struct{}
+
+func NewNoopTransport() (*Noop, error) {
+	return &Noop{}, nil
+}
+
+func (t *Noop) Connect() error {
+	return nil
+}
+
+func (t *Noop) Disconnect(quiesce uint) {}
+
+func (t *Noop) Tx(addr string, metadata map[string]string, data []byte) (responseCode int, responseMetadata map[string]string, responseData []byte, err error) {
+	return
+}
+
+func (t *Noop) SetRxHandler(f RxHandlerFunc) error {
+	return nil
+}
+
+func (t *Noop) ReloadTLSConfig(tlsConfig *tls.Config) error {
+	return nil
+}
+
+func (t *Noop) SetEventHandler(f EventHandlerFunc) error {
+	return nil
+}


### PR DESCRIPTION
Add a noop transport option. Setting the config flag 'protocol' to
"noop" or "" will configure yggd with a no-op transport. All the rest of
the dispatch and routing flows are unaffected, but no data is
transported to or from the client.