### PR TITLE
Correct godocs.io import path

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![godocs.io](https://godocs.io/github.com/RedHatInsights/yggdrasil?status.svg)](https://godocs.io/github.com/RedHatInsights/yggdrasil)
+[![godocs.io](https://godocs.io/github.com/redhatinsights/yggdrasil?status.svg)](https://godocs.io/github.com/redhatinsights/yggdrasil)
 
 # yggdrasil
 


### PR DESCRIPTION
Correct the godocs.io badge URL to the import path of the module.