### PR TITLE
fix: handle Event signals gracefully

### DIFF
--- a/internal/work/dispatcher_test.go
+++ b/internal/work/dispatcher_test.go
@@ -1,0 +1,104 @@
+package work
+
+import (
+	"testing"
+
+	"github.com/godbus/dbus/v5"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/redhatinsights/yggdrasil/ipc"
+)
+
+func TestWorkerEventFromSignal(t *testing.T) {
+	tests := []struct {
+		description string
+		input       *dbus.Signal
+		want        *ipc.WorkerEvent
+		wantError   error
+	}{
+		{
+			input: &dbus.Signal{
+				Name: "com.redhat.Yggdrasil1.Worker1.Event",
+				Body: []interface{}{uint32(1), "6925055f-167a-45cc-9869-1789ee37883f"},
+			},
+			want: &ipc.WorkerEvent{
+				Name:      ipc.WorkerEventNameBegin,
+				MessageID: "6925055f-167a-45cc-9869-1789ee37883f",
+			},
+		},
+		{
+			input: &dbus.Signal{
+				Name: "com.redhat.Yggdrasil1.Worker1.Event",
+				Body: []interface{}{uint32(2), "6925055f-167a-45cc-9869-1789ee37883f"},
+			},
+			want: &ipc.WorkerEvent{
+				Name:      ipc.WorkerEventNameEnd,
+				MessageID: "6925055f-167a-45cc-9869-1789ee37883f",
+			},
+		},
+		{
+			input: &dbus.Signal{
+				Name: "com.redhat.Yggdrasil1.Worker1.Event",
+				Body: []interface{}{uint32(3), "6925055f-167a-45cc-9869-1789ee37883f"},
+			},
+			want: &ipc.WorkerEvent{
+				Name:      ipc.WorkerEventNameWorking,
+				MessageID: "6925055f-167a-45cc-9869-1789ee37883f",
+			},
+		},
+		{
+			input: &dbus.Signal{
+				Name: "com.redhat.Yggdrasil1.Worker1.Event",
+				Body: []interface{}{uint32(3), "6925055f-167a-45cc-9869-1789ee37883f", "working message"},
+			},
+			want: &ipc.WorkerEvent{
+				Name:      ipc.WorkerEventNameWorking,
+				MessageID: "6925055f-167a-45cc-9869-1789ee37883f",
+				Message:   "working message",
+			},
+		},
+		{
+			input: &dbus.Signal{
+				Name: "com.redhat.Yggdrasil1.Worker1.Event",
+				Body: []interface{}{"3", "6925055f-167a-45cc-9869-1789ee37883f"},
+			},
+			want:      nil,
+			wantError: newUint32TypeConversionError("3"),
+		},
+		{
+			input: &dbus.Signal{
+				Name: "com.redhat.Yggdrasil1.Worker1.Event",
+				Body: []interface{}{uint32(1), 3},
+			},
+			want:      nil,
+			wantError: newStringTypeConversionError(3),
+		},
+		{
+			input: &dbus.Signal{
+				Name: "com.redhat.Yggdrasil1.Worker1.Event",
+				Body: []interface{}{uint32(3), "6925055f-167a-45cc-9869-1789ee37883f", 3},
+			},
+			want:      nil,
+			wantError: newStringTypeConversionError(3),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			got, err := workerEventFromSignal(test.input)
+
+			if test.wantError != nil {
+				if !cmp.Equal(err, test.wantError, cmpopts.EquateErrors()) {
+					t.Errorf("%#v != %#v", err, test.wantError)
+				}
+			} else {
+				if err != nil {
+					t.Fatal(err)
+				}
+				if !cmp.Equal(got, test.want) {
+					t.Errorf("%v", cmp.Diff(got, test.want))
+				}
+			}
+		})
+	}
+}

--- a/internal/work/errors.go
+++ b/internal/work/errors.go
@@ -1,0 +1,28 @@
+package work
+
+import "reflect"
+
+// typeConversionError represents a conversion error when converting one type
+// to  another.
+type typeConversionError struct {
+	p reflect.Value
+	t reflect.Type
+}
+
+func (e typeConversionError) Error() string {
+	return "cannot convert " + e.p.Type().Name() + " to " + e.t.Name()
+}
+
+func newUint32TypeConversionError(parameter interface{}) typeConversionError {
+	return typeConversionError{
+		p: reflect.ValueOf(parameter),
+		t: reflect.TypeOf(uint32(0)),
+	}
+}
+
+func newStringTypeConversionError(parameter interface{}) typeConversionError {
+	return typeConversionError{
+		p: reflect.ValueOf(parameter),
+		t: reflect.TypeOf(""),
+	}
+}


### PR DESCRIPTION
Return errors when handling Event signals emitted by workers and handle
the optional 'message' parameter gracefully.

Signed-off-by: Link Dupont <link@sub-pop.net>