### PR TITLE
feat(yggctl): Read content from files or stdin

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,8 +65,9 @@ Publish a "PING" command to the `yggd` "control/in" topic to test sending
 an MQTT message to `yggd`.
 
 ```
-go run ./cmd/yggctl generate control-message --type command '{"command":"ping"}' | \
-    pub -broker tcp://localhost:1883 -topic yggdrasil/$(hostname)/control/in
+echo '{"command":"ping"}' | \
+go run ./cmd/yggctl generate control-message --type command - | \
+pub -broker tcp://localhost:1883 -topic yggdrasil/$(hostname)/control/in
 ```
 
 You should see the message logged to the output of `sub` in [Terminal
@@ -78,8 +79,9 @@ You should see the message logged to the output of `sub` in [Terminal
 Now publish a data message containing the string "hello" to the `echo` worker.
 
 ```
-go run ./cmd/yggctl generate data-message --directive echo "hello" | \
-    pub -broker tcp://localhost:1883 -topic yggdrasil/$(hostname)/data/in
+echo "hello" | \
+go run ./cmd/yggctl generate data-message --directive echo - | \
+pub -broker tcp://localhost:1883 -topic yggdrasil/$(hostname)/data/in
 ```
 
 Again, you should see the message logged by the `sub` command in [Terminal
@@ -234,12 +236,13 @@ sub -broker tcp://localhost:1883 -topic yggdrasil/$(hostname)/data/in \
 
 ### Over MQTT
 
-A client can be sent a `PING` command by generated a control message and
+A client can be sent a `PING` command by generating a control message and
 publishing it to the client's "control/in" topic:
 
 ```
-yggctl generate control-message --type command '{"command":"ping"}' | \
-    pub -broker tcp://localhost:1883 -topic yggdrasil/$(hostname)/control/in
+echo '{"command":"ping"}' | \
+yggctl generate control-message --type command - | \
+pub -broker tcp://localhost:1883 -topic yggdrasil/$(hostname)/control/in
 ```
 
 Activity should occur on the terminal attached to `yggd`, and a `PONG` event
@@ -250,8 +253,9 @@ Similarly, a data message can be published to a client using `yggctl generate`
 and `pub`.
 
 ```
-yggctl generate data-message --directive echo hello | \
-    pub -broker tcp://localhost:1883 -topic yggdrasil/$(hostname)/data/in
+echo "hello" | \
+yggctl generate data-message --directive echo - | \
+pub -broker tcp://localhost:1883 -topic yggdrasil/$(hostname)/data/in
 ```
 
 ### Directly

--- a/cmd/yggctl/main.go
+++ b/cmd/yggctl/main.go
@@ -30,12 +30,16 @@ func main() {
 	app.Commands = []*cli.Command{
 		{
 			Name:   "generate",
-			Usage:  `Generate messages for publishing to client "in" topics.`,
+			Usage:  `Generate messages for publishing to client "in" topics`,
 			Hidden: true,
 			Subcommands: []*cli.Command{
 				{
-					Name:    "data-message",
-					Usage:   "Generate a data message.",
+					Name:      "data-message",
+					Usage:     "Generate a data message",
+					UsageText: "yggctl generate data-message [command options] FILE",
+					Description: `The generate data-message command reads FILE and prints a JSON object conforming
+to yggdrasil's JSON schema for 'data' messages. If FILE is -, content is read
+from stdin.`,
 					Aliases: []string{"data"},
 					Flags: []cli.Flag{
 						&cli.IntFlag{
@@ -65,8 +69,12 @@ func main() {
 					Action: generateDataMessageAction,
 				},
 				{
-					Name:    "control-message",
-					Usage:   "Generate a control message.",
+					Name:      "control-message",
+					Usage:     "Generate a control message",
+					UsageText: "yggctl generate control-message [command options] FILE",
+					Description: `The generate control-message command reads FILE and prints a JSON object conforming
+to yggdrasil's JSON schema for 'control' messages. If FILE is -, content is read
+from stdin.`,
 					Aliases: []string{"control"},
 					Flags: []cli.Flag{
 						&cli.IntFlag{


### PR DESCRIPTION
Update the generate data-message and generate control-message
subcommands to read message content from a file path passed as the first
positional argument on the commandline. Support the convention reading
from stdin if the file path is '-'.

Signed-off-by: Link Dupont <link@sub-pop.net>