### PR TITLE
ci: added golines lint checking

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -36,6 +36,11 @@ jobs:
         with:
           version: latest
           args: --verbose --timeout=3m
+      - name: Set up golines
+        run: go install github.com/segmentio/golines@latest
+      - name: Run golines
+        run: if [ "$(golines . --dry-run | wc -l)" -gt 0 ]; then exit 1; fi
+
   lint-language:
     name: Lint language
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -288,7 +288,7 @@ echo -n "hello" | yggctl dispatch -w "echo" -
 * Code should be formatted using `gofmt` and `goimports` before committing. As
   the saying goes ["gofmt's style is no one's favorite, yet gofmt is everyone's
   favorite."](https://www.youtube.com/watch?v=PAAkCSZUG1c&t=8m43s).
-* Code may optionally be formatted using
+* Code should be formatted using
   [`golines`](https://github.com/segmentio/golines), to wrap long lines.
 
 ## Required Reading


### PR DESCRIPTION
This PR adds golines checking to new PRs and prevents merging to main if it detects that the code has not been formatted for golines.

**Note:**
Not sure if there's a better way to do this, but If there's a way to automatically run golines on every PR during merging instead of requiring commits to comply to golines formatting then that might be a better solution. Of course that could introduce a potential for errors caused by golines to be merged into main so I'm not sure.