### PR TITLE
feat: Run yggd as non-root user by default

### DIFF
--- a/data/dbus/yggd.conf
+++ b/data/dbus/yggd.conf
@@ -4,19 +4,43 @@
  "-//freedesktop//DTD D-BUS Bus Configuration 1.0//EN"
  "https://dbus.freedesktop.org/doc/busconfig.dtd">
 <busconfig>
-  <policy user="root">
-    <!-- Only root can own the Dispatcher1 and Worker1.* destination names. -->
+  <policy user="yggd">
+    <!-- Only yggd can own the Yggdrasil1 destination name. -->
+    <allow own="com.redhat.Yggdrasil1"/>
+
+    <!-- Only yggd can own the Dispatcher1 and Worker1.* destination names. -->
     <allow own="com.redhat.Yggdrasil1.Dispatcher1"/>
     <allow own_prefix="com.redhat.Yggdrasil1.Worker1"/>
 
-    <!-- Only root can send messages to Dispatcher1 destination. -->
+    <!-- Only yggd can send messages to Dispatcher1 destination. -->
     <allow send_destination="com.redhat.Yggdrasil1.Dispatcher1"/>
-
-    <!-- Only root can own the Yggdrasil1 destination name. -->
-    <allow own="com.redhat.Yggdrasil1"/>
   </policy>
+
+  <policy group="ygg_worker">
+    <!-- Workers running as non-root users should be able to
+    call "Transmit" method, when worker is in group ygg_worker -->
+    <allow send_destination="com.redhat.Yggdrasil1.Dispatcher1"
+       send_interface="com.redhat.Yggdrasil1.Dispatcher1"
+       send_member="Transmit"/>
+  </policy>
+
+  <policy user="root">
+    <!-- Only workers should be able to call "Transmit" method -->
+    <allow send_destination="com.redhat.Yggdrasil1.Dispatcher1"
+       send_interface="com.redhat.Yggdrasil1.Dispatcher1"
+       send_member="Transmit"/>
+  </policy>
+
   <policy context="default">
-    <!-- Anyone can send messages to Yggdrasil destination. -->
-    <allow send_destination="com.redhat.Yggdrasil1"/>
+    <!-- Anybody should be able to get list of workers -->
+    <allow send_destination="com.redhat.Yggdrasil1"
+       send_interface="com.redhat.Yggdrasil1"
+       send_member="ListWorkers"/>
+
+    <!-- Everybody should be able to introspect D-Bus API -->
+    <allow send_destination="com.redhat.Yggdrasil1"
+      send_interface="org.freedesktop.DBus.Introspectable"/>
+    <allow send_destination="com.redhat.Yggdrasil1.Dispatcher1"
+      send_interface="org.freedesktop.DBus.Introspectable"/>
   </policy>
 </busconfig>

--- a/data/meson.build
+++ b/data/meson.build
@@ -1,4 +1,5 @@
 subdir('completion')
 subdir('dbus')
+subdir('service_user')
 subdir('systemd')
 subdir('yggdrasil')

--- a/data/service_user/create_sysuser.sh
+++ b/data/service_user/create_sysuser.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+USER_NAME="yggd"
+SYS_USER_DIR=$(pkg-config systemd --variable=sysusersdir)
+SYS_USER_CONF_FILE="${SYS_USER_DIR}"/"${USER_NAME}".conf
+
+# Create system user for running yggd
+if [[ -f "${DESTDIR}"/"${SYS_USER_CONF_FILE}" ]]; then
+  systemd-sysusers --root "${DESTDIR}" "${DESTDIR}"/"${SYS_USER_CONF_FILE}"
+else
+  echo "Error: ${SYS_USER_CONF_FILE} does not exist. Cannot create sys user: ${USER_NAME}"
+fi

--- a/data/service_user/meson.build
+++ b/data/service_user/meson.build
@@ -1,0 +1,5 @@
+install_data('yggd.conf',
+  install_dir: systemd.get_variable(pkgconfig: 'sysusersdir')
+  )
+
+# meson.add_install_script('create_sysuser.sh')

--- a/data/service_user/yggd.conf
+++ b/data/service_user/yggd.conf
@@ -1,0 +1,3 @@
+#Type   Name        ID    GECOS               Home directory      Shell
+u       yggd        -     "yggd system user"  /var/lib/yggdrasil  /sbin/nologin
+g       ygg_worker  -     -

--- a/data/yggdrasil/config.toml
+++ b/data/yggdrasil/config.toml
@@ -3,3 +3,8 @@
 protocol = "mqtt"
 server = ["tcp://test.mosquitto.org:1883"]
 log-level = "error"
+
+# If system user is changed to some other user, then
+# it is necessary to change policy file accordingly.
+# It is typically /usr/share/dbus-1/system.d/yggd.conf
+user = "yggd"

--- a/dist/srpm/yggdrasil.spec.in
+++ b/dist/srpm/yggdrasil.spec.in
@@ -116,8 +116,12 @@ export %gomodulesmode
 %{_datadir}/bash-completion/completions/*
 %{_datadir}/dbus-1/{interfaces,system-services,system.d}/*
 %{_datadir}/doc/%{name}/*
+%{_sysusersdir}/yggd.conf
 %{_mandir}/man1/*
 
 %if %{has_go_rpm_macros}
 %gopkgfiles
 %endif
+
+%post
+systemd-sysusers $(pkg-config systemd --variable=sysusersdir)/yggd.conf

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -31,6 +31,7 @@ const (
 	FlagNameMQTTConnectTimeout       = "mqtt-connect-timeout"
 	FlagNameMQTTPublishTimeout       = "mqtt-publish-timeout"
 	FlagNameMessageJournal           = "message-journal"
+	FlagNameServiceUser              = "user"
 )
 
 var DefaultConfig = Config{
@@ -111,6 +112,9 @@ type Config struct {
 	// MessageJournal is used to enable the storage of worker events
 	// and message data in a SQLite file at the specified file path.
 	MessageJournal string
+
+	// ServiceUser is the user used for running yggd service
+	ServiceUser string
 }
 
 // CreateTLSConfig creates a tls.Config object from the current configuration.

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -44,7 +44,10 @@ var (
 )
 
 func init() {
-	if os.Getuid() > 0 {
+	// User with UID == 0 is root. Users with UID in range 1..999
+	// are system users. More information about UIDs and GIDs
+	// could be found e.g. here: https://systemd.io/UIDS-GIDS/
+	if os.Getuid() >= 1000 {
 		ConfigDir = filepath.Join(xdg.ConfigHome, "yggdrasil")
 		StateDir = filepath.Join(xdg.StateHome, "yggdrasil")
 		CacheDir = filepath.Join(xdg.CacheHome, "yggdrasil")

--- a/internal/work/dispatcher.go
+++ b/internal/work/dispatcher.go
@@ -89,7 +89,7 @@ func (d *Dispatcher) Connect() error {
 
 	reply, err := d.conn.RequestName("com.redhat.Yggdrasil1.Dispatcher1", dbus.NameFlagDoNotQueue)
 	if err != nil {
-		return fmt.Errorf("cannot request name on bus: %v", err)
+		return fmt.Errorf("cannot request name com.redhat.Yggdrasil1.Dispatcher1 on bus: %v", err)
 	}
 
 	if reply != dbus.RequestNameReplyPrimaryOwner {
@@ -101,11 +101,17 @@ func (d *Dispatcher) Connect() error {
 	// Add a match signal on the
 	// org.freedesktop.DBus.Properties.PropertiesChanged signal.
 	if err := d.conn.AddMatchSignal(dbus.WithMatchPathNamespace("/com/redhat/Yggdrasil1/Worker1"), dbus.WithMatchInterface("org.freedesktop.DBus.Properties"), dbus.WithMatchMember("PropertiesChanged")); err != nil {
-		return fmt.Errorf("cannot add signal match: %v", err)
+		return fmt.Errorf(
+			"cannot add signal match on the org.freedesktop.DBus.Properties.PropertiesChanged: %v",
+			err,
+		)
 	}
 
 	if err := d.conn.AddMatchSignal(dbus.WithMatchPathNamespace("/com/redhat/Yggdrasil1/Worker1"), dbus.WithMatchInterface("com.redhat.Yggdrasil1.Worker1"), dbus.WithMatchMember("Event")); err != nil {
-		return fmt.Errorf("cannot add signal match: %v", err)
+		return fmt.Errorf(
+			"cannot add signal match on the com.redhat.Yggdrasil1.Worker1.Event: %v",
+			err,
+		)
 	}
 
 	// start goroutine that receives values on the signals channel and handles
@@ -197,11 +203,12 @@ func (d *Dispatcher) Dispatch(data yggdrasil.Data) error {
 		"com.redhat.Yggdrasil1.Worker1."+data.Directive,
 		dbus.ObjectPath(filepath.Join("/com/redhat/Yggdrasil1/Worker1/", data.Directive)),
 	)
-	r, err := obj.GetProperty("com.redhat.Yggdrasil1.Worker1.RemoteContent")
+	propertyName := "com.redhat.Yggdrasil1.Worker1.RemoteContent"
+	r, err := obj.GetProperty(propertyName)
 	if err != nil {
 		return fmt.Errorf(
-			"cannot get property 'com.redhat.Yggdrasil1.Worker1.RemoteContent': %v",
-			err,
+			"cannot get property '%s' of object: %s: using destination interface: %s: %v",
+			propertyName, obj.Path(), obj.Destination(), err,
 		)
 	}
 
@@ -247,7 +254,13 @@ func (d *Dispatcher) Dispatch(data yggdrasil.Data) error {
 		data.Content,
 	)
 	if err := call.Store(); err != nil {
-		return fmt.Errorf("cannot call Dispatch method on worker: %v", err)
+		return fmt.Errorf(
+			"cannot call 'Dispatch' method on worker: %s of object: %s: using destination interface: %s: %v",
+			data.Directive,
+			obj.Path(),
+			obj.Destination(),
+			err,
+		)
 	}
 	log.Debugf("send message %v to worker %v", data.MessageID, data.Directive)
 

--- a/worker/echo/com.redhat.Yggdrasil1.Worker1.echo.conf
+++ b/worker/echo/com.redhat.Yggdrasil1.Worker1.echo.conf
@@ -1,13 +1,36 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!DOCTYPE busconfig PUBLIC
- "-//freedesktop//DTD D-BUS Bus Configuration 1.0//EN"
- "https://dbus.freedesktop.org/doc/busconfig.dtd">
- <busconfig>
- <policy user="root">
-    <!-- Only root can send messages to the Worker1.echo destination. -->
-    <allow send_destination="com.redhat.Yggdrasil1.Worker1.echo" send_interface="com.redhat.Yggdrasil1.Worker1"/>
-    <allow send_destination="com.redhat.Yggdrasil1.Worker1.echo" send_interface="org.freedesktop.DBus.Properties"/>
-    <allow send_destination="com.redhat.Yggdrasil1.Worker1.echo" send_interface="org.freedesktop.DBus.Introspectable"/>
-</policy>
+  "-//freedesktop//DTD D-BUS Bus Configuration 1.0//EN"
+  "https://dbus.freedesktop.org/doc/busconfig.dtd">
+  <busconfig>
+  <policy user="echo_worker">
+    <allow own="com.redhat.Yggdrasil1.Worker1.echo"/>
+
+    <!--
+    Only service user echo_worker can send messages to the Worker1.echo destination.
+    -->
+    <allow send_destination="com.redhat.Yggdrasil1.Worker1.echo"
+      send_interface="com.redhat.Yggdrasil1.Worker1"/>
+  </policy>
+
+  <policy user="yggd">
+    <!--
+    The service user "yggd" used for running yggd service has to be able
+    to call Dispatch D-Bus method.
+    -->
+    <allow send_destination="com.redhat.Yggdrasil1.Worker1.echo"
+      send_interface="com.redhat.Yggdrasil1.Worker1"
+      send_member="Dispatch"/>
+
+    <!-- Only yggd can read properties of worker -->
+    <allow send_destination="com.redhat.Yggdrasil1.Worker1.echo"
+       send_interface="org.freedesktop.DBus.Properties"/>
+  </policy>
+
+  <policy context="default">
+    <!-- Everybody should be able to introspect D-Bus API of echo worker -->
+    <allow send_destination="com.redhat.Yggdrasil1.Worker1.echo"
+      send_interface="org.freedesktop.DBus.Introspectable"/>
+  </policy>
 </busconfig>

--- a/worker/echo/com.redhat.Yggdrasil1.Worker1.echo.service.in
+++ b/worker/echo/com.redhat.Yggdrasil1.Worker1.echo.service.in
@@ -1,4 +1,5 @@
 [D-BUS Service]
 Name=com.redhat.Yggdrasil1.Worker1.echo
-User=root
+User=echo_worker
+Group=ygg_worker
 Exec=@libexecdir@/yggdrasil/echo

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -77,6 +77,7 @@ func (w *Worker) Connect(quit <-chan os.Signal) error {
 		log.Debugf("connecting to session bus: %v", os.Getenv("DBUS_SESSION_BUS_ADDRESS"))
 		w.conn, err = dbus.ConnectSessionBus()
 	} else {
+		log.Debug("connecting to system bus")
 		w.conn, err = dbus.ConnectSystemBus()
 	}
 	if err != nil {
@@ -119,10 +120,10 @@ func (w *Worker) Connect(quit <-chan os.Signal) error {
 	// Request ownership of the well-known bus address.
 	reply, err := w.conn.RequestName(w.busName, dbus.NameFlagDoNotQueue)
 	if err != nil {
-		return fmt.Errorf("cannot request name on bus: %w", err)
+		return fmt.Errorf("cannot request name %s on bus: %w", w.busName, err)
 	}
 	if reply != dbus.RequestNameReplyPrimaryOwner {
-		return fmt.Errorf("request name failed")
+		return fmt.Errorf("request name failed: %v", reply)
 	}
 
 	// Emit a started event


### PR DESCRIPTION
* The yggd.service is run as non-root user by default.
  The username is yggd.
* System call `setgid()` and `setuid()` are used to change
  effective user and group used for running yggd service
* The user can be configured in `/etc/yggdrasil/config.toml`,
  but policy file has to be changed manually.
* When client-id file is created, then yggd tries to change
  owner to user and group configured in `config.toml` file
* Modified policy files to use yggd user (not root) and
 ` ygg_worker` group. It is still possible to run workers
  using root user. When worker is run as non-root user,
  then user has to be in group `ygg_worker`.
* Added install script for creating yggd service user
  and `ygg_worker` group
* Extended some error messages