### PR TITLE
Set version to 0.4.0

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ["1.18", "1.19"]
+        go: ["1.18", "1.19", "1.20"]
     steps:
       - name: Updating ...
         run: sudo apt-get -qq update

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -38,7 +38,7 @@ jobs:
       - uses: actions/download-artifact@v3
         with:
           name: yggdrasil-${{ github.sha }}
-      - run: mock --enable-network --rebuild --resultdir $GITHUB_WORKSPACE $GITHUB_WORKSPACE/*.src.rpm
+      - run: mock --verbose --enable-network --rebuild --resultdir $GITHUB_WORKSPACE $GITHUB_WORKSPACE/*.src.rpm
       - uses: actions/upload-artifact@v3
         with:
           name: yggdrasil-${{ matrix.image }}-${{ matrix.version }}

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('yggdrasil',
-        version: '0.3.2',
+        version: '0.4.0',
         meson_version: '>= 0.58.0')
 
 go = find_program('go')


### PR DESCRIPTION
The `main` branch currently contains [changes](https://github.com/RedHatInsights/yggdrasil/commit/5f12e93f9edf552e3a1b1a2d77b10185620d78c0) that will break clients expecting the D-Bus protocol that shipped with 0.3.2. While yggdrasil is still "not 1.0", I am trying to maintain as little API breakage as possible. Marking the next version as 0.4.0 hopefully signifies more explicitly that this version is different than previous versions. Clients will need to be updated in order to communicate with yggdrasil 0.4.0.