### PR TITLE
Add a delay before reconnecting to MQTT

### DIFF
--- a/cmd/yggd/main.go
+++ b/cmd/yggd/main.go
@@ -65,6 +65,7 @@ func setupDefaultConfig(c *cli.Context) {
 		MQTTConnectRetry:         c.Bool(config.FlagNameMQTTConnectRetry),
 		MQTTConnectRetryInterval: c.Duration(config.FlagNameMQTTConnectRetryInterval),
 		MQTTAutoReconnect:        c.Bool(config.FlagNameMQTTAutoReconnect),
+		MQTTReconnectDelay:       c.Duration(config.FlagNameMQTTReconnectDelay),
 	}
 }
 
@@ -506,6 +507,12 @@ func main() {
 			Name:   config.FlagNameMQTTAutoReconnect,
 			Usage:  "Enable automatic reconnection when the client disconnects",
 			Value:  true,
+			Hidden: true,
+		}),
+		altsrc.NewDurationFlag(&cli.DurationFlag{
+			Name:   config.FlagNameMQTTReconnectDelay,
+			Usage:  "Sets the time to wait before attempting to reconnect to `DURATION`",
+			Value:  0 * time.Second,
 			Hidden: true,
 		}),
 	}

--- a/cmd/yggd/main.go
+++ b/cmd/yggd/main.go
@@ -50,18 +50,21 @@ func generateDocumentation(c *cli.Context) error {
 // CLI flags and arguments.
 func setupDefaultConfig(c *cli.Context) {
 	config.DefaultConfig = config.Config{
-		LogLevel:       c.String(config.FlagNameLogLevel),
-		ClientID:       c.String(config.FlagNameClientID),
-		Server:         c.StringSlice(config.FlagNameServer),
-		CertFile:       c.String(config.FlagNameCertFile),
-		KeyFile:        c.String(config.FlagNameKeyFile),
-		CARoot:         c.StringSlice(config.FlagNameCaRoot),
-		PathPrefix:     c.String(config.FlagNamePathPrefix),
-		Protocol:       c.String(config.FlagNameProtocol),
-		DataHost:       c.String(config.FlagNameDataHost),
-		CanonicalFacts: c.String(config.FlagNameCanonicalFacts),
-		HTTPRetries:    c.Int(config.FlagNameHTTPRetries),
-		HTTPTimeout:    c.Duration(config.FlagNameHTTPTimeout),
+		LogLevel:                 c.String(config.FlagNameLogLevel),
+		ClientID:                 c.String(config.FlagNameClientID),
+		Server:                   c.StringSlice(config.FlagNameServer),
+		CertFile:                 c.String(config.FlagNameCertFile),
+		KeyFile:                  c.String(config.FlagNameKeyFile),
+		CARoot:                   c.StringSlice(config.FlagNameCaRoot),
+		PathPrefix:               c.String(config.FlagNamePathPrefix),
+		Protocol:                 c.String(config.FlagNameProtocol),
+		DataHost:                 c.String(config.FlagNameDataHost),
+		CanonicalFacts:           c.String(config.FlagNameCanonicalFacts),
+		HTTPRetries:              c.Int(config.FlagNameHTTPRetries),
+		HTTPTimeout:              c.Duration(config.FlagNameHTTPTimeout),
+		MQTTConnectRetry:         c.Bool(config.FlagNameMQTTConnectRetry),
+		MQTTConnectRetryInterval: c.Duration(config.FlagNameMQTTConnectRetryInterval),
+		MQTTAutoReconnect:        c.Bool(config.FlagNameMQTTAutoReconnect),
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -27,6 +27,7 @@ const (
 	FlagNameMQTTConnectRetry         = "mqtt-connect-retry"
 	FlagNameMQTTConnectRetryInterval = "mqtt-connect-retry-interval"
 	FlagNameMQTTAutoReconnect        = "mqtt-auto-reconnect"
+	FlagNameMQTTReconnectDelay       = "mqtt-reconnect-delay"
 )
 
 var DefaultConfig = Config{
@@ -91,6 +92,10 @@ type Config struct {
 	// MQTTAutoReconnect is the MQTT client option that enables automatic
 	// reconnection logic when the client unexpectedly disconnects.
 	MQTTAutoReconnect bool
+
+	// MQTTReconnectDelay is the duration the client with wait before attempting
+	// to reconnect to the MQTT broker.
+	MQTTReconnectDelay time.Duration
 }
 
 // CreateTLSConfig creates a tls.Config object from the current configuration.

--- a/internal/transport/mqtt.go
+++ b/internal/transport/mqtt.go
@@ -99,6 +99,17 @@ func NewMQTTTransport(clientID string, brokers []string, tlsConfig *tls.Config) 
 		t.events <- TransporterEventDisconnected
 	})
 
+	opts.SetReconnectingHandler(func(c mqtt.Client, co *mqtt.ClientOptions) {
+		if config.DefaultConfig.MQTTReconnectDelay > 0 {
+			log.Infof(
+				"delaying for %v before reconnecting...",
+				config.DefaultConfig.MQTTReconnectDelay,
+			)
+			time.Sleep(config.DefaultConfig.MQTTReconnectDelay)
+		}
+		log.Debugf("reconnecting to broker: %v", co.Servers)
+	})
+
 	data, err := json.Marshal(&yggdrasil.ConnectionStatus{
 		Type:      yggdrasil.MessageTypeConnectionStatus,
 		MessageID: uuid.New().String(),


### PR DESCRIPTION
Add a new hidden flag: --mqtt-reconnect-delay. This flag will sleep for the given duration before attempting to reconnect to the MQTT broker. This only works if --mqtt-auto-reconnect is enabled (it is true by default).

I also noticed that the previously added MQTT flags were not set into the DefaultConfig struct, so their values when read from the struct were always the zero value. I fixed this in a separate commit on this same PR.