### PR TITLE
feat(mqtt): Use Token.WaitTimeout

### DIFF
--- a/cmd/yggd/main.go
+++ b/cmd/yggd/main.go
@@ -66,6 +66,8 @@ func setupDefaultConfig(c *cli.Context) {
 		MQTTConnectRetryInterval: c.Duration(config.FlagNameMQTTConnectRetryInterval),
 		MQTTAutoReconnect:        c.Bool(config.FlagNameMQTTAutoReconnect),
 		MQTTReconnectDelay:       c.Duration(config.FlagNameMQTTReconnectDelay),
+		MQTTConnectTimeout:       c.Duration(config.FlagNameMQTTConnectTimeout),
+		MQTTPublishTimeout:       c.Duration(config.FlagNameMQTTPublishTimeout),
 	}
 }
 
@@ -346,7 +348,7 @@ func mainAction(c *cli.Context) error {
 	// from the Transporter
 	client, transporter, err := setupClient(dispatcher, tlsConfig)
 	if err != nil {
-		return err
+		return cli.Exit(fmt.Errorf("cannot setup client: %w", err), 1)
 	}
 
 	// Create watcher for certificate changes
@@ -513,6 +515,18 @@ func main() {
 			Name:   config.FlagNameMQTTReconnectDelay,
 			Usage:  "Sets the time to wait before attempting to reconnect to `DURATION`",
 			Value:  0 * time.Second,
+			Hidden: true,
+		}),
+		altsrc.NewDurationFlag(&cli.DurationFlag{
+			Name:   config.FlagNameMQTTConnectTimeout,
+			Usage:  "Sets the time to wait before giving up to `DURATION` when connecting to an MQTT broker",
+			Value:  30 * time.Second,
+			Hidden: true,
+		}),
+		altsrc.NewDurationFlag(&cli.DurationFlag{
+			Name:   config.FlagNameMQTTPublishTimeout,
+			Usage:  "Sets the time to wait before giving up to `DURATION` when publishing a message to an MQTT broker",
+			Value:  30 * time.Second,
 			Hidden: true,
 		}),
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -28,6 +28,8 @@ const (
 	FlagNameMQTTConnectRetryInterval = "mqtt-connect-retry-interval"
 	FlagNameMQTTAutoReconnect        = "mqtt-auto-reconnect"
 	FlagNameMQTTReconnectDelay       = "mqtt-reconnect-delay"
+	FlagNameMQTTConnectTimeout       = "mqtt-connect-timeout"
+	FlagNameMQTTPublishTimeout       = "mqtt-publish-timeout"
 )
 
 var DefaultConfig = Config{
@@ -96,6 +98,14 @@ type Config struct {
 	// MQTTReconnectDelay is the duration the client with wait before attempting
 	// to reconnect to the MQTT broker.
 	MQTTReconnectDelay time.Duration
+
+	// MQTTConnectTimeout is the duration the client will wait for an MQTT
+	// connection to be established before giving up.
+	MQTTConnectTimeout time.Duration
+
+	// MQTTPublishTimeout is the duration the client will wait for an MQTT
+	// connection to publish a message before giving up.
+	MQTTPublishTimeout time.Duration
 }
 
 // CreateTLSConfig creates a tls.Config object from the current configuration.


### PR DESCRIPTION
When connecting to a broker and when publishing a message, use the
`Token.WaitTimeout` method instead of `Token.Wait`. `Token.Wait` waits
indefinitely, which can lead to situations when the client never
succeeds in connecting or publishing.

The timeout for each operation can be configured independently by
setting `mqtt-connect-timeout` and `mqtt-publish-timeout`. Both values
default to 30 seconds. The flags are hidden, as they should not commonly
be required to be changed by users.

Signed-off-by: Link Dupont <link@sub-pop.net>