### PR TITLE
Packaging fixes

### DIFF
--- a/dist/srpm/meson.build
+++ b/dist/srpm/meson.build
@@ -17,7 +17,7 @@ tarball = custom_target('tarball',
     '--gzip',
     '--absolute-names',
     '--file', '@OUTPUT@',
-    '--transform', 's+@0@+@1@-@2@+'.format(meson.project_source_root(), meson.project_name(), commit),
+    '--transform', 's+@0@+@1@-@2@+'.format(meson.project_source_root(), meson.project_name(), meson.project_version()),
     '--exclude', build_root_basename,
     '--exclude', '.git',
     '--exclude', '.vscode',
@@ -25,7 +25,7 @@ tarball = custom_target('tarball',
     '--exclude', '.copr',
     meson.project_source_root()
   ],
-  output: '@0@-@1@.tar.gz'.format(meson.project_name(), commit)
+  output: '@0@-@1@.tar.gz'.format(meson.project_name(), meson.project_version())
 )
 
 specfile = configure_file(

--- a/dist/srpm/yggdrasil.spec.in
+++ b/dist/srpm/yggdrasil.spec.in
@@ -8,6 +8,8 @@
 
 %bcond_without check
 
+%global has_go_rpm_macros (0%{?fedora} || 0%{?rhel} >= 9)
+
 # must be before %%gometa
 Version:        @VERSION@
 
@@ -17,10 +19,13 @@ Version:        @VERSION@
 %global shortcommit     %(c=%{commit}; echo ${c:0:7})
 %global archivename     yggdrasil-%{version}
 
-%if 0%{?fedora}
-%gometa -f
+%if %{has_go_rpm_macros}
+%gometa %{?fedora:-f}
 %else
-%gometa
+%global gourl https://github.com/RedHatInsights/%{name}
+%global gomodulesmode GO111MODULES=off
+%global gosource %{gourl}/releases/download/%{version}/yggdrasil-%{version}.tar.gz
+%global gocompilerflags "-buildmode pie -compiler gc"
 %endif
 
 # Manually redefine %%dist to work around an issue in COPR where the build root
@@ -60,13 +65,15 @@ BuildRequires:  pkgconfig(bash-completion)
 
 %description %{common_description}
 
+%if %{has_go_rpm_macros}
 %gopkg
+%endif
 
 %prep
-%if 0%{?fedora}
-%goprep
+%if %{has_go_rpm_macros}
+%goprep %{?rhel:-k}
 %else
-%goprep -k
+%autosetup
 %endif
 
 %if 0%{?fedora}
@@ -84,11 +91,17 @@ export %gomodulesmode
 %global gosupfiles ./ipc/com.redhat.Yggdrasil1.Dispatcher1.xml ./ipc/com.redhat.Yggdrasil1.Worker1.xml
 %install
 %meson_install
+%if %{has_go_rpm_macros}
 %gopkginstall
+%endif
 
 %if %{with check}
 %check
+%if %{has_go_rpm_macros}
 %gocheck
+%else
+%meson_test
+%endif
 %endif
 
 %files
@@ -104,4 +117,6 @@ export %gomodulesmode
 %{_datadir}/doc/%{name}/*
 %{_mandir}/man1/*
 
+%if %{has_go_rpm_macros}
 %gopkgfiles
+%endif

--- a/dist/srpm/yggdrasil.spec.in
+++ b/dist/srpm/yggdrasil.spec.in
@@ -8,10 +8,14 @@
 
 %bcond_without check
 
+# must be before %%gometa
+Version:        @VERSION@
+
 # https://github.com/redhatinsights/yggdrasil
 %global goipath         github.com/redhatinsights/yggdrasil
 %global commit          @COMMIT@
 %global shortcommit     %(c=%{commit}; echo ${c:0:7})
+%global archivename     yggdrasil-%{version}
 
 %if 0%{?fedora}
 %gometa -f
@@ -41,7 +45,6 @@ exchanging data with its worker processes through a D-Bus message broker.}
 %global godocs          CONTRIBUTING.md README.md
 
 Name:           yggdrasil
-Version:        @VERSION@
 Release:        0%{?dist}
 Summary:        Remote data transmission and processing client
 

--- a/dist/srpm/yggdrasil.spec.in
+++ b/dist/srpm/yggdrasil.spec.in
@@ -62,6 +62,7 @@ BuildRequires:  meson
 BuildRequires:  pkgconfig(dbus-1)
 BuildRequires:  pkgconfig(systemd)
 BuildRequires:  pkgconfig(bash-completion)
+BuildRequires:  golang >= 1.18
 
 %description %{common_description}
 


### PR DESCRIPTION
This tweaks the available RPM packaging so it can be used also on EL 8; high-level summary of the changes:
- the Go (S)RPM macros are used only if available, falling back to other macros or setting fallback variables to reduce differences
- generate an upstream tarball compatible with what older RPM versions expect

See the messages of each commit for longer explanations.