### PR TITLE
fix: build RPM packages as part of our CI 

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -2,6 +2,7 @@ name: Package
 
 on:
   push:
+  pull_request:
 
 jobs:
   build-srpm:


### PR DESCRIPTION
* The building of package was not trigger, when PR was opened.
  This commit fixes this issue