### PR TITLE
build: install git-core insted of git

### DIFF
--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -14,7 +14,7 @@ help:
 
 .PHONY: srpm
 srpm:
-	dnf install --assumeyes bash-completion git go meson 'pkgconfig(dbus-1)' 'pkgconfig(systemd)' rpm-build
+	dnf install --assumeyes bash-completion git-core go meson 'pkgconfig(dbus-1)' 'pkgconfig(systemd)' rpm-build
 	meson setup builddir -Dbuild_srpm=True -Dvendor=True -Dexamples=True
 	meson compile srpm -C builddir
 	mv builddir/dist/srpm/*.src.rpm $(outdir)


### PR DESCRIPTION
Only the basic `git` tool is needed, so avoid pulling the extra bits (e.g. Perl) when building the SRPM in Copr.