### PR TITLE
Use .copr/Makefile for COPR and Packit builds

### DIFF
--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -7,14 +7,27 @@
 # N.B.: This Makefile should not be used to build an SRPM manually. Instead,
 # see 'dist/srpm' on how to use meson to build an SRPM manually.
 
+outdir ?= $(PWD)/outdir
+
 .PHONY: help
 help:
 	@echo "This Makefile is not intended to be run manually."
 	@echo "Run 'meson compile srpm' instead."
 
 .PHONY: srpm
-srpm:
-	dnf install --assumeyes bash-completion git-core go meson 'pkgconfig(dbus-1)' 'pkgconfig(systemd)' rpm-build
+srpm: deps
+	mkdir -p $(outdir)
 	meson setup builddir -Dbuild_srpm=True -Dvendor=True -Dexamples=True
 	meson compile srpm -C builddir
 	mv builddir/dist/srpm/*.src.rpm $(outdir)
+
+deps:
+	rpm -qa > /tmp/rpm-list ; \
+	grep '^golang-[0-9]' /tmp/rpm-list && \
+	grep '^git-core-[0-9]' /tmp/rpm-list && \
+	grep '^meson-[0-9]' /tmp/rpm-list && \
+	grep '^bash-completion-[0-9]' /tmp/rpm-list && \
+	grep '^rpm-build-[0-9]' /tmp/rpm-list && \
+	grep '^dbus-1.[0-9]' /tmp/rpm-list && \
+	grep '^systemd-[0-9]' /tmp/rpm-list || \
+	dnf install -y bash-completion git-core go meson 'pkgconfig(dbus-1)' 'pkgconfig(systemd)' rpm-build

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -15,8 +15,7 @@ srpm_build_deps:
 actions:
   post-upstream-clone:
     - mkdir out
-    - meson setup builddir -Dbuild_srpm=True -Dvendor=True -Dexamples=True
-    - meson compile srpm -C builddir
+    - make -f .copr/Makefile srpm outdir=out/
     - bash -c 'mv builddir/dist/srpm/* out/'
   get-current-version:
     - awk '/^Version:/ {print $2;}' out/yggdrasil.spec


### PR DESCRIPTION
* It is important to have single source of truth. It is `.copr/Makefile`
   in this case. It triggers building of SRPM with same CLI options
   for COPR and Packit. There was danger of changing only one
   configuration  (e.g. `.packit`) and not change `.copr/Makefile`
   which could result in different results from COPR and Packit build.
* Use the same Makefile (same CLI arguments) for triggering
   build on COPR and packit
* Fix of `.copr/Makefile`: When required RPMs have been already
   installed, then do not try to install these RPMS once again