### PR TITLE
feat: start workers explicitly

### DIFF
--- a/cmd/yggd/exec.go
+++ b/cmd/yggd/exec.go
@@ -5,215 +5,70 @@ import (
 	"io"
 	"os"
 	"os/exec"
-	"path/filepath"
-	"strconv"
-	"strings"
-	"time"
-
-	"git.sr.ht/~spc/go-log"
-	"github.com/redhatinsights/yggdrasil"
-	"github.com/rjeczalik/notify"
 )
 
-func startProcess(file string, env []string, delay time.Duration, died chan int) {
+// startProcess executes file, setting up the environment using the provided
+// env values. If started is not nil, it is invoked on a goroutine after the
+// process has been started.
+func startProcess(file string, args []string, env []string, started func(pid int, stdout io.ReadCloser, stderr io.ReadCloser)) error {
 	if _, err := os.Stat(file); os.IsNotExist(err) {
-		log.Warnf("cannot start worker: %v", err)
-		return
+		return fmt.Errorf("cannot find file: %v", err)
 	}
 
-	cmd := exec.Command(file)
+	cmd := exec.Command(file, args...)
 	cmd.Env = env
-
-	if delay < 0 {
-		log.Errorf("failed to start worker '%v' too many times", file)
-		return
-	}
-
-	if delay > 0 {
-		log.Tracef("delaying worker start for %v...", delay)
-		time.Sleep(delay)
-	}
 
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
-		log.Errorf("cannot connect to stdout: %v", err)
-		return
+		return fmt.Errorf("cannot connect to stdout: %v", err)
 	}
 
 	stderr, err := cmd.StderrPipe()
 	if err != nil {
-		log.Errorf("cannot connect to stderr: %v", err)
-		return
+		return fmt.Errorf("cannot connect to stderr: %v", err)
 	}
 
 	if err := cmd.Start(); err != nil {
-		log.Errorf("cannot start worker: %v: %v", file, err)
-		return
-	}
-	log.Debugf("started process: %v", cmd.Process.Pid)
-
-	go func() {
-		for {
-			buf := make([]byte, 4096)
-			n, err := stdout.Read(buf)
-			if n > 0 {
-				log.Tracef("[%v] %v", file, strings.TrimRight(string(buf), "\n\x00"))
-			}
-			if err != nil {
-				switch err {
-				case io.EOF:
-					log.Debugf("%v stdout reached EOF: %v", file, err)
-					return
-				default:
-					log.Errorf("cannot read from stdout: %v", err)
-					continue
-				}
-			}
-		}
-	}()
-
-	go func() {
-		for {
-			buf := make([]byte, 4096)
-			n, err := stderr.Read(buf)
-			if n > 0 {
-				log.Errorf("[%v] %v", file, strings.TrimRight(string(buf), "\n\x00"))
-			}
-			if err != nil {
-				switch err {
-				case io.EOF:
-					log.Debugf("%v stderr reached EOF: %v", file, err)
-					return
-				default:
-					log.Errorf("cannot read from stderr: %v", err)
-					continue
-				}
-			}
-		}
-	}()
-
-	pidDirPath := filepath.Join(yggdrasil.LocalstateDir, "run", yggdrasil.LongName, "workers")
-
-	if err := os.MkdirAll(pidDirPath, 0755); err != nil {
-		log.Errorf("cannot create directory: %v", err)
-		return
+		return fmt.Errorf("cannot start process: %v: %v", file, err)
 	}
 
-	if err := os.WriteFile(filepath.Join(pidDirPath, filepath.Base(file)+".pid"), []byte(fmt.Sprintf("%v", cmd.Process.Pid)), 0644); err != nil {
-		log.Errorf("cannot write to file: %v", err)
-		return
+	if started != nil {
+		go started(cmd.Process.Pid, stdout, stderr)
 	}
 
-	go watchProcess(cmd, delay, died)
+	return nil
 }
 
-func watchProcess(cmd *exec.Cmd, delay time.Duration, died chan int) {
-	log.Debugf("watching process: %v", cmd.Process.Pid)
-
-	state, err := cmd.Process.Wait()
+// waitProcess finds a process with the given pid and waits for it to exit.
+// If died is not nil, it is invoked on a goroutine when the process exits.
+func waitProcess(pid int, died func(pid int, state *os.ProcessState)) error {
+	process, err := os.FindProcess(pid)
 	if err != nil {
-		log.Errorf("process %v exited with error: %v", cmd.Process.Pid, err)
+		return fmt.Errorf("cannot find process with pid: %v", err)
 	}
 
-	died <- state.Pid()
-
-	if state.SystemTime() < time.Duration(1*time.Second) {
-		delay += 5 * time.Second
-	}
-	if delay >= time.Duration(30*time.Second) {
-		delay = -1
+	state, err := process.Wait()
+	if err != nil {
+		return fmt.Errorf("process %v exited with error: %v", process.Pid, err)
 	}
 
-	go startProcess(cmd.Path, cmd.Env, delay, died)
+	if died != nil {
+		go died(process.Pid, state)
+	}
+
+	return nil
 }
 
-func killProcess(pid int) error {
-	process, err := os.FindProcess(int(pid))
+// stopProcess finds a process with the given pid and kills it.
+func stopProcess(pid int) error {
+	process, err := os.FindProcess(pid)
 	if err != nil {
-		return fmt.Errorf("cannot find process with pid: %w", err)
+		return fmt.Errorf("cannot find process with pid: %v", err)
 	}
+
 	if err := process.Kill(); err != nil {
-		log.Errorf("cannot kill process: %v", err)
-	} else {
-		log.Infof("killed process %v", process.Pid)
-	}
-	return nil
-}
-
-func killWorker(pidFile string) error {
-	data, err := os.ReadFile(pidFile)
-	if err != nil {
-		return fmt.Errorf("cannot read contents of file: %w", err)
-	}
-	pid, err := strconv.ParseInt(string(data), 10, 64)
-	if err != nil {
-		return fmt.Errorf("cannot parse file contents as int: %w", err)
-	}
-
-	if err := killProcess(int(pid)); err != nil {
-		return fmt.Errorf("cannot kill process: %w", err)
-	}
-
-	if err := os.Remove(pidFile); err != nil {
-		return fmt.Errorf("cannot remove file: %w", err)
-	}
-	return nil
-}
-
-func killWorkers() error {
-	pidDirPath := filepath.Join(yggdrasil.LocalstateDir, "run", yggdrasil.LongName, "workers")
-	if err := os.MkdirAll(pidDirPath, 0755); err != nil {
-		return fmt.Errorf("cannot create directory: %w", err)
-	}
-	fileInfos, err := os.ReadDir(pidDirPath)
-	if err != nil {
-		return fmt.Errorf("cannot read contents of directory: %w", err)
-	}
-
-	for _, info := range fileInfos {
-		pidFilePath := filepath.Join(pidDirPath, info.Name())
-		if err := killWorker(pidFilePath); err != nil {
-			return fmt.Errorf("cannot kill worker: %w", err)
-		}
+		return fmt.Errorf("cannot stop process: %v", err)
 	}
 
 	return nil
-}
-
-func watchWorkerDir(dir string, env []string, died chan int) {
-	c := make(chan notify.EventInfo, 1)
-
-	if err := notify.Watch(dir, c, notify.InCloseWrite, notify.InDelete, notify.InMovedFrom, notify.InMovedTo); err != nil {
-		log.Errorf("cannot start notify watchpoint: %v", err)
-		return
-	}
-	defer notify.Stop(c)
-
-	for e := range c {
-		log.Debugf("received inotify event %v", e.Event())
-		switch e.Event() {
-		case notify.InCloseWrite, notify.InMovedTo:
-			if strings.HasSuffix(e.Path(), "worker") {
-				if ExcludeWorkers[filepath.Base(e.Path())] {
-					continue
-				}
-				log.Tracef("new worker detected: %v", e.Path())
-				go startProcess(e.Path(), env, 0, died)
-			}
-		case notify.InDelete, notify.InMovedFrom:
-			workerName := filepath.Base(e.Path())
-			pidFilePath := filepath.Join(
-				yggdrasil.LocalstateDir,
-				"run",
-				yggdrasil.LongName,
-				"workers",
-				workerName+".pid",
-			)
-
-			if err := killWorker(pidFilePath); err != nil {
-				log.Errorf("cannot kill worker: %v", err)
-				continue
-			}
-		}
-	}
 }

--- a/cmd/yggd/exec_test.go
+++ b/cmd/yggd/exec_test.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"io"
+	"testing"
+)
+
+func TestStartProcess(t *testing.T) {
+	tests := []struct {
+		description string
+		input       struct {
+			file string
+			args []string
+			env  []string
+		}
+	}{
+		{
+			input: struct {
+				file string
+				args []string
+				env  []string
+			}{
+				file: "/usr/bin/sleep",
+				args: []string{"1"},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			err := startProcess(test.input.file, test.input.args, test.input.env, nil)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestStopProcess(t *testing.T) {
+	tests := []struct {
+		description string
+		input       struct {
+			file string
+			args []string
+			env  []string
+		}
+	}{
+		{
+			input: struct {
+				file string
+				args []string
+				env  []string
+			}{
+				file: "/usr/bin/sleep",
+				args: []string{"3"},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			err := startProcess(test.input.file, test.input.args, test.input.env, func(pid int, stdout, stderr io.ReadCloser) {
+				if err := stopProcess(pid); err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+			})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestWaitProcess(t *testing.T) {
+	tests := []struct {
+		description string
+		input       struct {
+			file string
+			args []string
+			env  []string
+		}
+	}{
+		{
+			input: struct {
+				file string
+				args []string
+				env  []string
+			}{
+				file: "/usr/bin/sleep",
+				args: []string{"3"},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+
+			err := startProcess(test.input.file, test.input.args, test.input.env, func(pid int, stdout, stderr io.ReadCloser) {
+				if err := waitProcess(pid, nil); err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+			})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}

--- a/cmd/yggd/util.go
+++ b/cmd/yggd/util.go
@@ -53,3 +53,33 @@ func parseCertCN(filename string) (string, error) {
 	}
 	return cert.Subject.CommonName, nil
 }
+
+// createClientID will generate a semi-random string to be used as the MQTT
+// client ID and save the value to the client-id file.
+func createClientID(file string) ([]byte, error) {
+	if _, err := os.Stat(file); os.IsExist(err) {
+		return nil, fmt.Errorf("cannot create client-id: %w", err)
+	}
+
+	data := []byte(randomString(64))
+
+	if err := setClientID(data, file); err != nil {
+		return nil, fmt.Errorf("cannot set client-id: %w", err)
+	}
+
+	return data, nil
+}
+
+// setClientID writes data to the client ID file.
+func setClientID(data []byte, file string) error {
+	if err := os.MkdirAll(filepath.Dir(file), 0750); err != nil {
+		return fmt.Errorf("cannot create directory: %w", err)
+	}
+
+	if err := os.WriteFile(file, data, 0600); err != nil {
+		return fmt.Errorf("cannot write file: %w", err)
+	}
+
+	return nil
+
+}

--- a/cmd/yggd/worker.go
+++ b/cmd/yggd/worker.go
@@ -1,0 +1,265 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"git.sr.ht/~spc/go-log"
+	"github.com/pelletier/go-toml"
+	"github.com/redhatinsights/yggdrasil"
+	"github.com/rjeczalik/notify"
+	"golang.org/x/net/http/httpproxy"
+)
+
+type workerConfig struct {
+	Exec      string   `toml:"exec"`
+	Protocol  string   `toml:"protocol"`
+	Env       []string `toml:"env"`
+	delay     time.Duration
+	directive string
+}
+
+// loadWorkerConfig reads the contents of file and parses it into a workerConfig
+// value.
+func loadWorkerConfig(file string) (*workerConfig, error) {
+	data, err := os.ReadFile(file)
+	if err != nil {
+		return nil, fmt.Errorf("cannot read file: %w", err)
+	}
+
+	var config workerConfig
+	if err := toml.Unmarshal(data, &config); err != nil {
+		return nil, fmt.Errorf("cannot load config: %w", err)
+	}
+	config.directive = strings.TrimSuffix(filepath.Base(file), filepath.Ext(file))
+
+	return &config, nil
+}
+
+// startWorker constructs a command to execute from the given workerConfig,
+// starts it, and starts a goroutine that waits for the process to exit. If not
+// nil, started is invoked after the process is started. Likewise, when the
+// process is stopped, stopped is invoked.
+func startWorker(config workerConfig, started func(pid int), stopped func(pid int)) error {
+	argv := strings.Split(config.Exec, " ")
+
+	program := argv[0]
+	var args []string
+	if len(argv) > 1 {
+		args = argv[1:]
+	}
+
+	env := []string{
+		"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+		"YGG_CONFIG_DIR=" + filepath.Join(yggdrasil.SysconfDir, yggdrasil.LongName),
+		"YGG_LOG_LEVEL=" + log.CurrentLevel().String(),
+		"YGG_CLIENT_ID=" + ClientID,
+	}
+
+	proxy := httpproxy.FromEnvironment()
+	if proxy.HTTPProxy != "" {
+		env = append(env, "HTTP_PROXY="+proxy.HTTPProxy)
+	}
+	if proxy.HTTPSProxy != "" {
+		env = append(env, "HTTPS_PROXY="+proxy.HTTPSProxy)
+	}
+	if proxy.NoProxy != "" {
+		env = append(env, "NO_PROXY="+proxy.NoProxy)
+	}
+
+	switch config.Protocol {
+	case "grpc":
+		env = append(env, "YGG_SOCKET_ADDR=unix:"+SocketAddr)
+	default:
+		return fmt.Errorf("unsupported protocol: %v", config.Protocol)
+	}
+
+	for _, val := range config.Env {
+		if validEnvVar(val) {
+			env = append(env, val)
+		}
+	}
+
+	if config.delay < 0 {
+		return fmt.Errorf("failed to start worker %v too many times", program)
+	}
+
+	if config.delay > 0 {
+		log.Tracef("delaying worker start for %v...", config.delay)
+		time.Sleep(config.delay)
+	}
+
+	err := startProcess(program, args, env, func(pid int, stdout, stderr io.ReadCloser) {
+		go func() {
+			scanner := bufio.NewScanner(stdout)
+			for scanner.Scan() {
+				log.Debugf("%v: %v", program, scanner.Text())
+			}
+			if err := scanner.Err(); err != nil {
+				log.Errorf("cannot read from stdout: %v", err)
+			}
+		}()
+
+		go func() {
+			scanner := bufio.NewScanner(stderr)
+			for scanner.Scan() {
+				log.Warnf("%v: %v", program, scanner.Text())
+			}
+			if err := scanner.Err(); err != nil {
+				log.Errorf("cannot read from stderr: %v", err)
+			}
+		}()
+
+		pidDirPath := filepath.Join(yggdrasil.LocalstateDir, "run", yggdrasil.LongName, "workers")
+
+		if err := os.MkdirAll(pidDirPath, 0755); err != nil {
+			log.Errorf("cannot create directory: %v", err)
+			return
+		}
+
+		if err := os.WriteFile(filepath.Join(pidDirPath, config.directive+".pid"), []byte(fmt.Sprintf("%v", pid)), 0644); err != nil {
+			log.Errorf("cannot write to file: %v", err)
+			return
+		}
+
+		if started != nil {
+			go started(pid)
+		}
+
+		if err := waitProcess(pid, func(pid int, state *os.ProcessState) {
+			log.Infof("worker stopped: %v", pid)
+
+			if state.SystemTime() < time.Duration(1*time.Second) {
+				config.delay += 5 * time.Second
+			}
+
+			if config.delay >= time.Duration(30*time.Second) {
+				config.delay = -1
+			}
+
+			if stopped != nil {
+				go stopped(pid)
+			}
+
+			if workerExists(config.directive) {
+				if err := startWorker(config, started, stopped); err != nil {
+					log.Errorf("cannot restart worker: %v", err)
+					return
+				}
+			}
+		}); err != nil {
+			log.Errorf("process exited with an error: %v", err)
+		}
+	})
+
+	if err != nil {
+		return fmt.Errorf("cannot start worker: %w", err)
+	}
+
+	return nil
+}
+
+// stopWorker looks for a PID file with the given name, parses it as a integer,
+// assumes it is a process PID and stops the process.
+func stopWorker(name string) error {
+	pidFile := filepath.Join(yggdrasil.LocalstateDir, "run", yggdrasil.LongName, "workers", name+".pid")
+
+	data, err := os.ReadFile(pidFile)
+	if err != nil {
+		return fmt.Errorf("cannot read file: %w", err)
+	}
+	pid, err := strconv.ParseInt(strings.TrimSpace(string(data)), 10, 64)
+	if err != nil {
+		return fmt.Errorf("cannot parse data: %w", err)
+	}
+	if err := stopProcess(int(pid)); err != nil {
+		return fmt.Errorf("cannot stop worker: %w", err)
+	}
+	if err := os.Remove(pidFile); err != nil {
+		return fmt.Errorf("cannot remove file: %w", err)
+	}
+	return nil
+}
+
+// stopWorkers reads all pid files from the local state directory and attempts
+// to stop the worker process.
+func stopWorkers() error {
+	dir := filepath.Join(yggdrasil.LocalstateDir, "run", yggdrasil.LongName, "workers")
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return fmt.Errorf("cannot create directory: %w", err)
+	}
+	infos, err := os.ReadDir(dir)
+	if err != nil {
+		return fmt.Errorf("cannot read contents of directory: %w", err)
+	}
+
+	for _, info := range infos {
+		if strings.HasSuffix(info.Name(), ".pid") {
+			if err := stopWorker(strings.TrimSuffix(info.Name(), ".pid")); err != nil {
+				return fmt.Errorf("cannot stop worker: %w", err)
+			}
+		}
+	}
+
+	return nil
+}
+
+func watchWorkerDir(dir string, died chan int) {
+	c := make(chan notify.EventInfo, 1)
+
+	if err := notify.Watch(dir, c, notify.InCloseWrite, notify.InDelete, notify.InMovedFrom, notify.InMovedTo); err != nil {
+		log.Errorf("cannot start notify watchpoint: %v", err)
+		return
+	}
+	defer notify.Stop(c)
+
+	for e := range c {
+		log.Debugf("received inotify event %v", e.Event())
+		switch e.Event() {
+		case notify.InCloseWrite, notify.InMovedTo:
+			log.Tracef("new worker detected: %v", e.Path())
+			config, err := loadWorkerConfig(e.Path())
+			if err != nil {
+				log.Errorf("cannot load worker config: %v", err)
+			}
+			go func() {
+				if err := startWorker(*config, nil, func(pid int) {
+					died <- pid
+				}); err != nil {
+					log.Errorf("cannot start worker: %v", err)
+					return
+				}
+			}()
+		case notify.InDelete, notify.InMovedFrom:
+			name := strings.TrimSuffix(filepath.Base(e.Path()), filepath.Ext(e.Path()))
+
+			if err := stopWorker(name); err != nil {
+				log.Errorf("cannot kill worker: %v", err)
+				continue
+			}
+		}
+	}
+}
+
+func workerExists(name string) bool {
+	_, err := os.Stat(filepath.Join(yggdrasil.SysconfDir, yggdrasil.LongName, "workers", name+".toml"))
+	return !os.IsNotExist(err)
+}
+
+func validEnvVar(val string) bool {
+	for _, pattern := range []string{"PATH=.*", "YGG_.*=.*"} {
+		r := regexp.MustCompile(pattern)
+		if r.Match([]byte(val)) {
+			return false
+		}
+	}
+
+	return true
+}

--- a/cmd/yggd/worker_test.go
+++ b/cmd/yggd/worker_test.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+)
+
+func TestValidEnvVar(t *testing.T) {
+	tests := []struct {
+		description string
+		input       string
+		want        bool
+	}{
+		{
+			description: "invalid: PATH",
+			input:       "PATH=/opt/bin:$PATH",
+			want:        false,
+		},
+		{
+			description: "valid: HTTP_PROXY",
+			input:       "HTTP_PROXY=http://localhost:8080",
+			want:        true,
+		},
+		{
+			description: "invalid: YGG_SOCKET_ADDR",
+			input:       "YGG_SOCKET_ADDR=@yggd",
+			want:        false,
+		},
+		{
+			description: "valid: YGGD_VERSION",
+			input:       "YGGD_VERSION=1.2.3",
+			want:        true,
+		},
+		{
+			description: "invalid: YGG_VERSION",
+			input:       "YGG_VERSION=1.2.3",
+			want:        false,
+		},
+		{
+			description: "invalid: YGG_=",
+			input:       "YGG_=",
+			want:        false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			got := validEnvVar(test.input)
+
+			if !cmp.Equal(got, test.want) {
+				t.Errorf("%#v != %#v", got, test.want)
+			}
+		})
+	}
+}
+
+func TestStartWorker(t *testing.T) {
+	tests := []struct {
+		description string
+		input       workerConfig
+		want        string
+		wantError   error
+	}{
+		{
+			input: workerConfig{
+				Exec:      "/usr/bin/echo test",
+				Protocol:  "grpc",
+				Env:       []string{},
+				delay:     0,
+				directive: "echo-test",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			err := startWorker(test.input, nil, nil)
+
+			if test.wantError != nil {
+				if !cmp.Equal(err, test.wantError, cmpopts.EquateErrors()) {
+					t.Errorf("%#v != %#v", err, test.wantError)
+				}
+			} else {
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+		})
+	}
+}

--- a/worker/echo/echo.toml
+++ b/worker/echo/echo.toml
@@ -1,0 +1,3 @@
+exec = "/usr/local/libexec/yggdrasil/ygg-echo-worker"
+protocol = "grpc"
+env = []


### PR DESCRIPTION
Workers are now started and stopped based on the existence of a configuration file in SYSCONFDIR/yggdrasil/workers. It defines a path to the executable that will be started and managed by yggd. Conversely, the worker can be disabled by the removal of the configuration file.

Much of the code in exec.go was lifted into a new workers.go file. exec.go now containers lower level routines for starting and stopping processes. It has no awareness of the concept of a "worker". workers.go has higher-level functions that use the startProcess and stopProcess routines to start a worker process, create a PID file, wait for exit status, restart and backoff restart delays, etc.

The sample echo worker config file has been updated to include two new fields: protocol and env. protocol must be set to a supported RPC protocol (currently "grpc" is the only supported RPC protocol). Any strings in env must be in the form of a "VAR=VALUE" string, and are inserted into the worker process's environment before starting. It is forbidden to set PATH or any variable beginning with YGG_ in a worker's configuration file. Any variables by these names will be omitted when starting the worker process.