### PR TITLE
build: remove 'go mod tidy'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -168,7 +168,6 @@ dist:
 
 .PHONY: clean
 clean:
-	go mod tidy
 	rm $(BINS)
 	rm $(DATA)
 


### PR DESCRIPTION
Drop 'go mod tidy' from the 'clean' Makefile target.