### PR TITLE
Configurable worker environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ pkg-config --variable workerexecdir yggdrasil
 /usr/local/libexec/yggdrasil
 ```
 
-A worker program must implement the `Worker` service.  `yggd` will execute
+A worker program must implement the `Worker` service. `yggd` will execute
 worker programs at start up. It will set the `YGG_SOCKET_ADDR` variable in the
 worker's environment. This address is the socket on which the worker must dial
 the dispatcher and call the "Register" RPC method. Upon successful registration,
@@ -81,3 +81,19 @@ the worker will receive back a socket address. The worker must bind to and
 listen on this address for RPC methods. See `worker/echo` for an example worker
 process that does nothing more than return the content data it received from the
 dispatcher.
+
+Additionally, `HTTP_PROXY`, `HTTPS_PROXY` and `NO_PROXY` (and their lowercase
+equivalents) are automatically read from `yggd`'s environment and added to the
+worker's environment. Any additional environment variables required may be set
+in a configuration file (see below).
+
+## Worker Configuration
+
+A TOML configuration file may optionaly be instaleld into
+`$SYSCONFDIR/yggdrasil/workers`. The file may be used to configure the worker
+startup procedure. The following table includes valid fields for a
+worker configuration file:
+
+| **Field**  | **Value** | **Description** |
+| ---------- | --------- | --------------- |
+| `env`      | `array`   | Any additional values that a worker needs inserted into its runtime enviroment before starting up. `PATH` and all variables beginning with `YGG_` are forbidden and may not be overridden. |

--- a/cmd/yggd/exec.go
+++ b/cmd/yggd/exec.go
@@ -5,135 +5,84 @@ import (
 	"io"
 	"os"
 	"os/exec"
-	"path/filepath"
-	"strings"
-	"time"
 
 	"git.sr.ht/~spc/go-log"
-	"github.com/redhatinsights/yggdrasil"
 )
 
-func startProcess(file string, env []string, delay time.Duration, died chan int) {
+type processStartedFunc func(pid int, stdout, stderr io.ReadCloser)
+type processStoppedFunc func(pid int, state *os.ProcessState)
+
+// startProcess executes file, setting up the environment using the provided env
+// values. If the function parameter started is not nil, it is invoked on a
+// goroutine after the process has been started.
+func startProcess(
+	file string,
+	args []string,
+	env []string,
+	started processStartedFunc,
+) error {
 	if _, err := os.Stat(file); os.IsNotExist(err) {
-		log.Warnf("cannot start worker: %v", err)
-		return
+		return fmt.Errorf("cannot find file: %v", err)
 	}
 
-	cmd := exec.Command(file)
+	cmd := exec.Command(file, args...)
 	cmd.Env = env
-
-	if delay < 0 {
-		log.Errorf("failed to start worker '%v' too many times", file)
-		return
-	}
-
-	if delay > 0 {
-		log.Tracef("delaying worker start for %v...", delay)
-		time.Sleep(delay)
-	}
 
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
-		log.Errorf("cannot connect to stdout: %v", err)
-		return
+		return fmt.Errorf("cannot connect to stdout: %v", err)
 	}
 
 	stderr, err := cmd.StderrPipe()
 	if err != nil {
-		log.Errorf("cannot connect to stderr: %v", err)
-		return
+		return fmt.Errorf("cannot connect to stderr: %v", err)
 	}
 
 	if err := cmd.Start(); err != nil {
-		log.Errorf("cannot start worker: %v: %v", file, err)
-		return
+		return fmt.Errorf("cannot start worker: %v: %v", file, err)
+
 	}
 	log.Debugf("started process: %v", cmd.Process.Pid)
 
-	go func() {
-		for {
-			buf := make([]byte, 4096)
-			n, err := stdout.Read(buf)
-			if n > 0 {
-				log.Tracef("[%v] %v", file, strings.TrimRight(string(buf), "\n\x00"))
-			}
-			if err != nil {
-				switch err {
-				case io.EOF:
-					log.Debugf("%v stdout reached EOF: %v", file, err)
-					return
-				default:
-					log.Errorf("cannot read from stdout: %v", err)
-					continue
-				}
-			}
-		}
-	}()
-
-	go func() {
-		for {
-			buf := make([]byte, 4096)
-			n, err := stderr.Read(buf)
-			if n > 0 {
-				log.Errorf("[%v] %v", file, strings.TrimRight(string(buf), "\n\x00"))
-			}
-			if err != nil {
-				switch err {
-				case io.EOF:
-					log.Debugf("%v stderr reached EOF: %v", file, err)
-					return
-				default:
-					log.Errorf("cannot read from stderr: %v", err)
-					continue
-				}
-			}
-		}
-	}()
-
-	pidDirPath := filepath.Join(yggdrasil.LocalstateDir, "run", yggdrasil.LongName, "workers")
-
-	if err := os.MkdirAll(pidDirPath, 0755); err != nil {
-		log.Errorf("cannot create directory: %v", err)
-		return
+	if started != nil {
+		go started(cmd.Process.Pid, stdout, stderr)
 	}
 
-	if err := os.WriteFile(filepath.Join(pidDirPath, filepath.Base(file)+".pid"), []byte(fmt.Sprintf("%v", cmd.Process.Pid)), 0644); err != nil {
-		log.Errorf("cannot write to file: %v", err)
-		return
-	}
-
-	go watchProcess(cmd, delay, died)
+	return nil
 }
 
-func watchProcess(cmd *exec.Cmd, delay time.Duration, died chan int) {
-	log.Debugf("watching process: %v", cmd.Process.Pid)
-
-	state, err := cmd.Process.Wait()
+// waitProcess finds a process with the given pid and waits for it to exit.
+// If the function parameter stopped is not nil, it is invoked on a goroutine
+// when the process exits.
+func waitProcess(pid int, stopped processStoppedFunc) error {
+	process, err := os.FindProcess(pid)
 	if err != nil {
-		log.Errorf("process %v exited with error: %v", cmd.Process.Pid, err)
+		return fmt.Errorf("cannot find process with pid: %v", err)
 	}
 
-	died <- state.Pid()
-
-	if state.SystemTime() < time.Duration(1*time.Second) {
-		delay += 5 * time.Second
-	}
-	if delay >= time.Duration(30*time.Second) {
-		delay = -1
+	log.Debugf("waiting for process: %v", process.Pid)
+	state, err := process.Wait()
+	if err != nil {
+		return fmt.Errorf("process %v exited with error: %v", process.Pid, err)
 	}
 
-	go startProcess(cmd.Path, cmd.Env, delay, died)
+	if stopped != nil {
+		go stopped(process.Pid, state)
+	}
+
+	return nil
 }
 
-func killProcess(pid int) error {
-	process, err := os.FindProcess(int(pid))
+// stopProcess finds a process with the given pid and kills it.
+func stopProcess(pid int) error {
+	process, err := os.FindProcess(pid)
 	if err != nil {
-		return fmt.Errorf("cannot find process with pid: %w", err)
+		return fmt.Errorf("cannot find process with pid: %v", err)
 	}
+
 	if err := process.Kill(); err != nil {
-		log.Errorf("cannot kill process: %v", err)
-	} else {
-		log.Infof("killed process %v", process.Pid)
+		return fmt.Errorf("cannot stop process %v", err)
 	}
+
 	return nil
 }

--- a/cmd/yggd/exec.go
+++ b/cmd/yggd/exec.go
@@ -6,13 +6,11 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"time"
 
 	"git.sr.ht/~spc/go-log"
 	"github.com/redhatinsights/yggdrasil"
-	"github.com/rjeczalik/notify"
 )
 
 func startProcess(file string, env []string, delay time.Duration, died chan int) {
@@ -138,82 +136,4 @@ func killProcess(pid int) error {
 		log.Infof("killed process %v", process.Pid)
 	}
 	return nil
-}
-
-func killWorker(pidFile string) error {
-	data, err := os.ReadFile(pidFile)
-	if err != nil {
-		return fmt.Errorf("cannot read contents of file: %w", err)
-	}
-	pid, err := strconv.ParseInt(string(data), 10, 64)
-	if err != nil {
-		return fmt.Errorf("cannot parse file contents as int: %w", err)
-	}
-
-	if err := killProcess(int(pid)); err != nil {
-		return fmt.Errorf("cannot kill process: %w", err)
-	}
-
-	if err := os.Remove(pidFile); err != nil {
-		return fmt.Errorf("cannot remove file: %w", err)
-	}
-	return nil
-}
-
-func killWorkers() error {
-	pidDirPath := filepath.Join(yggdrasil.LocalstateDir, "run", yggdrasil.LongName, "workers")
-	if err := os.MkdirAll(pidDirPath, 0755); err != nil {
-		return fmt.Errorf("cannot create directory: %w", err)
-	}
-	fileInfos, err := os.ReadDir(pidDirPath)
-	if err != nil {
-		return fmt.Errorf("cannot read contents of directory: %w", err)
-	}
-
-	for _, info := range fileInfos {
-		pidFilePath := filepath.Join(pidDirPath, info.Name())
-		if err := killWorker(pidFilePath); err != nil {
-			return fmt.Errorf("cannot kill worker: %w", err)
-		}
-	}
-
-	return nil
-}
-
-func watchWorkerDir(dir string, env []string, died chan int) {
-	c := make(chan notify.EventInfo, 1)
-
-	if err := notify.Watch(dir, c, notify.InCloseWrite, notify.InDelete, notify.InMovedFrom, notify.InMovedTo); err != nil {
-		log.Errorf("cannot start notify watchpoint: %v", err)
-		return
-	}
-	defer notify.Stop(c)
-
-	for e := range c {
-		log.Debugf("received inotify event %v", e.Event())
-		switch e.Event() {
-		case notify.InCloseWrite, notify.InMovedTo:
-			if strings.HasSuffix(e.Path(), "worker") {
-				if ExcludeWorkers[filepath.Base(e.Path())] {
-					continue
-				}
-				log.Tracef("new worker detected: %v", e.Path())
-				go startProcess(e.Path(), env, 0, died)
-			}
-		case notify.InDelete, notify.InMovedFrom:
-			workerName := filepath.Base(e.Path())
-			pidFilePath := filepath.Join(
-				yggdrasil.LocalstateDir,
-				"run",
-				yggdrasil.LongName,
-				"workers",
-				workerName+".pid",
-			)
-
-			if err := killWorker(pidFilePath); err != nil {
-				log.Errorf("cannot kill worker: %v", err)
-				continue
-			}
-		}
-	}
 }

--- a/cmd/yggd/exec_test.go
+++ b/cmd/yggd/exec_test.go
@@ -1,0 +1,126 @@
+package main
+
+import (
+	"io"
+	"os"
+	"testing"
+)
+
+func TestStartProcess(t *testing.T) {
+	tests := []struct {
+		description string
+		input       struct {
+			file string
+			args []string
+			env  []string
+		}
+	}{
+		{
+			input: struct {
+				file string
+				args []string
+				env  []string
+			}{
+				file: "/usr/bin/sleep",
+				args: []string{"1"},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			err := startProcess(test.input.file, test.input.args, test.input.env, nil)
+			if err != nil {
+				t.Fatalf("unable to start process: %v", err)
+			}
+		})
+	}
+}
+
+func TestStopProcess(t *testing.T) {
+	tests := []struct {
+		description string
+		input       struct {
+			file string
+			args []string
+			env  []string
+		}
+	}{
+		{
+			input: struct {
+				file string
+				args []string
+				env  []string
+			}{
+				file: "/usr/bin/sleep",
+				args: []string{"3"},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			err := startProcess(
+				test.input.file,
+				test.input.args,
+				test.input.env,
+				func(pid int, stdout, stderr io.ReadCloser) {
+					if err := stopProcess(pid); err != nil {
+						t.Fatalf("unable to stop process: %v", err)
+					}
+				},
+			)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestWaitProcess(t *testing.T) {
+	tests := []struct {
+		description string
+		input       struct {
+			file string
+			args []string
+			env  []string
+		}
+	}{
+		{
+			input: struct {
+				file string
+				args []string
+				env  []string
+			}{
+				file: "/usr/bin/sleep",
+				args: []string{"3"},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+
+			err := startProcess(
+				test.input.file,
+				test.input.args,
+				test.input.env,
+				func(startPid int, stdout, stderr io.ReadCloser) {
+					if err := waitProcess(startPid, func(stopPid int, state *os.ProcessState) {
+						if startPid != stopPid {
+							t.Fatalf("%v != %v", startPid, stopPid)
+						}
+						if !state.Exited() {
+							t.Fatalf("unexpected process exit state")
+						}
+					}); err != nil {
+						t.Fatalf("unable to wait for process with pid %v: %v", startPid, err)
+					}
+				},
+			)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}

--- a/cmd/yggd/util.go
+++ b/cmd/yggd/util.go
@@ -53,3 +53,8 @@ func parseCertCN(filename string) (string, error) {
 	}
 	return cert.Subject.CommonName, nil
 }
+
+func fileExists(f string) bool {
+	_, err := os.Stat(f)
+	return !os.IsNotExist(err)
+}

--- a/cmd/yggd/worker.go
+++ b/cmd/yggd/worker.go
@@ -2,60 +2,271 @@ package main
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strconv"
 	"strings"
+	"time"
 
 	"git.sr.ht/~spc/go-log"
+	"github.com/pelletier/go-toml"
 	"github.com/redhatinsights/yggdrasil"
 	"github.com/rjeczalik/notify"
+	"golang.org/x/net/http/httpproxy"
 )
 
-func killWorker(pidFile string) error {
+type workerStartedFunc func(pid int)
+type workerStoppedFunc func(pid int)
+
+// workerConfig holds information necessary to start and manage a worker
+// process.
+type workerConfig struct {
+	// Env is a slice of "KEY=VALUE" strings that get inserted into the worker's
+	// environment when it is started.
+	Env []string `toml:"env"`
+
+	// delay is the current time to delay the worker if it is in a crash backoff
+	// loop.
+	delay time.Duration
+
+	// program is the absolute path to the worker executable program.
+	program string
+}
+
+// loadWorkerConfig reads the contents of file and parses it into a workerConfig
+// value.
+func loadWorkerConfig(file string) (*workerConfig, error) {
+	data, err := os.ReadFile(file)
+	if err != nil {
+		return nil, fmt.Errorf("cannot read file: %w", err)
+	}
+
+	var config workerConfig
+	if err := toml.Unmarshal(data, &config); err != nil {
+		return nil, fmt.Errorf("cannot load config: %w", err)
+	}
+
+	return &config, nil
+}
+
+// startWorker starts a worker represented by the given config. If the started
+// function parameter is not nil, it is invoked when the worker process is
+// successfully started. If the worker is successfully started, the process is
+// waited upon until it stops. If the stopped function parameter is not nil, it
+// is invoked when the worker process is stopped.
+func startWorker(config workerConfig, started workerStartedFunc, stopped workerStoppedFunc) error {
+	if config.program == "" {
+		return fmt.Errorf("cannot start worker without program: %v", config)
+	}
+
+	env := []string{
+		"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+		"YGG_SOCKET_ADDR=unix:" + SocketAddr,
+		"YGG_CONFIG_DIR=" + filepath.Join(yggdrasil.SysconfDir, yggdrasil.LongName),
+		"YGG_LOG_LEVEL=" + log.CurrentLevel().String(),
+		"YGG_CLIENT_ID=" + ClientID,
+	}
+
+	proxy := httpproxy.FromEnvironment()
+	if proxy.HTTPProxy != "" {
+		env = append(env, "HTTP_PROXY="+proxy.HTTPProxy)
+		env = append(env, "http_proxy="+proxy.HTTPProxy)
+	}
+	if proxy.HTTPSProxy != "" {
+		env = append(env, "HTTPS_PROXY="+proxy.HTTPSProxy)
+		env = append(env, "https_proxy="+proxy.HTTPSProxy)
+	}
+	if proxy.NoProxy != "" {
+		env = append(env, "NO_PROXY="+proxy.NoProxy)
+		env = append(env, "no_proxy="+proxy.NoProxy)
+	}
+
+	for _, val := range config.Env {
+		if validEnvVar(val) {
+			env = append(env, val)
+		}
+	}
+
+	if config.delay < 0 {
+		return fmt.Errorf("failed to start worker %v too many times", config.program)
+	}
+
+	if config.delay > 0 {
+		log.Tracef("delaying worker start for %v...", config.delay)
+		time.Sleep(config.delay)
+	}
+
+	err := startProcess(config.program, nil, env, func(pid int, stdout, stderr io.ReadCloser) {
+		log.Infof("started worker: %v", config.program)
+
+		pipe := func(r io.ReadCloser) {
+			for {
+				buf := make([]byte, 4096)
+				n, err := r.Read(buf)
+				if n > 0 {
+					log.Tracef("[%v] %v", config.program, strings.TrimRight(string(buf), "\n\x00"))
+				}
+				if err != nil {
+					switch err {
+					case io.EOF:
+						log.Debugf("%v reached EOF: %v", config.program, err)
+						return
+					default:
+						log.Errorf("cannot read from reader: %v", err)
+						continue
+					}
+				}
+			}
+		}
+
+		go pipe(stdout)
+		go pipe(stderr)
+
+		pidDirPath := filepath.Join(yggdrasil.LocalstateDir, "run", yggdrasil.LongName, "workers")
+
+		if err := os.MkdirAll(pidDirPath, 0755); err != nil {
+			log.Errorf("cannot create directory: %v", err)
+			return
+		}
+
+		if err := os.WriteFile(filepath.Join(pidDirPath, filepath.Base(config.program)+".pid"), []byte(fmt.Sprintf("%v", pid)), 0644); err != nil {
+			log.Errorf("cannot write to file: %v", err)
+			return
+		}
+
+		if started != nil {
+			go started(pid)
+		}
+
+		err := waitProcess(pid, func(pid int, state *os.ProcessState) {
+			log.Infof("stopped worker: %v", config.program)
+			if state.SystemTime() < 1*time.Second {
+				config.delay += 5 * time.Second
+			}
+
+			if config.delay >= 30*time.Second {
+				config.delay = -1
+			}
+
+			if stopped != nil {
+				go stopped(pid)
+			}
+
+			if err := startWorker(config, started, stopped); err != nil {
+				log.Errorf("cannot restart worker: %v", err)
+				return
+			}
+		})
+		if err != nil {
+			log.Errorf("process exited with an error: %v", err)
+			return
+		}
+	})
+	if err != nil {
+		return fmt.Errorf("cannot start worker: %v", err)
+	}
+
+	return nil
+}
+
+// stopWorker attempts to stop a worker with the given name.
+func stopWorker(name string) error {
+	pidFile := filepath.Join(
+		yggdrasil.LocalstateDir,
+		"run",
+		yggdrasil.LongName,
+		"workers",
+		name+".pid",
+	)
+
 	data, err := os.ReadFile(pidFile)
 	if err != nil {
-		return fmt.Errorf("cannot read contents of file: %w", err)
+		return fmt.Errorf("cannot read file: %w", err)
 	}
-	pid, err := strconv.ParseInt(string(data), 10, 64)
+	pid, err := strconv.ParseInt(strings.TrimSpace(string(data)), 10, 64)
 	if err != nil {
-		return fmt.Errorf("cannot parse file contents as int: %w", err)
+		return fmt.Errorf("cannot parse data: %w", err)
 	}
 
-	if err := killProcess(int(pid)); err != nil {
-		return fmt.Errorf("cannot kill process: %w", err)
+	if err := stopProcess(int(pid)); err != nil {
+		return fmt.Errorf("cannot stop worker: %w", err)
 	}
-
 	if err := os.Remove(pidFile); err != nil {
 		return fmt.Errorf("cannot remove file: %w", err)
 	}
 	return nil
 }
 
-func killWorkers() error {
-	pidDirPath := filepath.Join(yggdrasil.LocalstateDir, "run", yggdrasil.LongName, "workers")
-	if err := os.MkdirAll(pidDirPath, 0755); err != nil {
-		return fmt.Errorf("cannot create directory: %w", err)
-	}
-	fileInfos, err := os.ReadDir(pidDirPath)
+// startWorkers reads the contents of the worker executable directory and starts
+// any valid workers found.
+func startWorkers(started workerStartedFunc, stopped workerStoppedFunc) error {
+	workerExecDir := filepath.Join(yggdrasil.LibexecDir, yggdrasil.LongName)
+	workerConfigDir := filepath.Join(yggdrasil.SysconfDir, yggdrasil.LongName, "workers")
+
+	infos, err := os.ReadDir(workerExecDir)
 	if err != nil {
-		return fmt.Errorf("cannot read contents of directory: %w", err)
+		return fmt.Errorf("cannot read worker directory: %v", err)
 	}
 
-	for _, info := range fileInfos {
-		pidFilePath := filepath.Join(pidDirPath, info.Name())
-		if err := killWorker(pidFilePath); err != nil {
-			return fmt.Errorf("cannot kill worker: %w", err)
+	for _, info := range infos {
+		if validWorker(info.Name()) {
+			var config *workerConfig
+
+			configFile := filepath.Join(workerConfigDir, info.Name()+".toml")
+			if fileExists(configFile) {
+				var err error
+
+				config, err = loadWorkerConfig(configFile)
+				if err != nil {
+					return fmt.Errorf("cannot read worker config file: %w", err)
+				}
+			} else {
+				config = &workerConfig{}
+			}
+			config.program = filepath.Join(workerExecDir, info.Name())
+
+			if err := startWorker(*config, started, stopped); err != nil {
+				return fmt.Errorf("cannot start worker %v: %w", info.Name(), err)
+			}
 		}
 	}
 
 	return nil
 }
 
-func watchWorkerDir(dir string, env []string, died chan int) {
+// stopWorkers reads all PID files from the local state directory and attempts
+// to stop the worker process.
+func stopWorkers() error {
+	dir := filepath.Join(yggdrasil.LocalstateDir, "run", yggdrasil.LongName, "workers")
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return fmt.Errorf("cannot create directory: %w", err)
+	}
+	infos, err := os.ReadDir(dir)
+	if err != nil {
+		return fmt.Errorf("cannot read contents of directory: %w", err)
+	}
+
+	for _, info := range infos {
+		if strings.HasSuffix(info.Name(), ".pid") {
+			if err := stopWorker(strings.TrimSuffix(info.Name(), ".pid")); err != nil {
+				return fmt.Errorf("cannot stop worker: %w", err)
+			}
+		}
+	}
+
+	return nil
+}
+
+// watchWorkerDir watches the worker exec directory for file modifications and
+// restarts workers when appropriate.
+func watchWorkerDir(died chan int) {
+	workerExecDir := filepath.Join(yggdrasil.LibexecDir, yggdrasil.LongName)
+	workerConfigDir := filepath.Join(yggdrasil.SysconfDir, yggdrasil.LongName, "workers")
 	c := make(chan notify.EventInfo, 1)
 
-	if err := notify.Watch(dir, c, notify.InCloseWrite, notify.InDelete, notify.InMovedFrom, notify.InMovedTo); err != nil {
+	if err := notify.Watch(workerExecDir, c, notify.InCloseWrite, notify.InDelete, notify.InMovedFrom, notify.InMovedTo); err != nil {
 		log.Errorf("cannot start notify watchpoint: %v", err)
 		return
 	}
@@ -65,27 +276,53 @@ func watchWorkerDir(dir string, env []string, died chan int) {
 		log.Debugf("received inotify event %v", e.Event())
 		switch e.Event() {
 		case notify.InCloseWrite, notify.InMovedTo:
-			if strings.HasSuffix(e.Path(), "worker") {
-				if ExcludeWorkers[filepath.Base(e.Path())] {
+			name := filepath.Base(e.Path())
+			if validWorker(name) {
+				var config *workerConfig
+
+				configFile := filepath.Join(workerConfigDir, name+".toml")
+				if fileExists(configFile) {
+					var err error
+
+					config, err = loadWorkerConfig(configFile)
+					if err != nil {
+						log.Errorf("cannot read worker config file: %v", err)
+						continue
+					}
+				} else {
+					config = &workerConfig{}
+				}
+				config.program = filepath.Join(workerExecDir, name)
+
+				if err := startWorker(*config, nil, func(pid int) {
+					died <- pid
+				}); err != nil {
+					log.Errorf("cannot start worker %v: %v", config.program, err)
 					continue
 				}
-				log.Tracef("new worker detected: %v", e.Path())
-				go startProcess(e.Path(), env, 0, died)
 			}
 		case notify.InDelete, notify.InMovedFrom:
 			workerName := filepath.Base(e.Path())
-			pidFilePath := filepath.Join(
-				yggdrasil.LocalstateDir,
-				"run",
-				yggdrasil.LongName,
-				"workers",
-				workerName+".pid",
-			)
-
-			if err := killWorker(pidFilePath); err != nil {
-				log.Errorf("cannot kill worker: %v", err)
+			if err := stopWorker(workerName); err != nil {
+				log.Errorf("cannot stop worker: %v", err)
 				continue
 			}
 		}
 	}
+}
+
+func validEnvVar(val string) bool {
+	for _, pattern := range []string{"PATH=.*", "YGG_.*=.*"} {
+		r := regexp.MustCompile(pattern)
+		if r.Match([]byte(val)) {
+			log.Warnf("invalid environment variable detected: %v", val)
+			return false
+		}
+	}
+
+	return true
+}
+
+func validWorker(name string) bool {
+	return strings.HasSuffix(name, "worker") && !ExcludeWorkers[name]
 }

--- a/cmd/yggd/worker.go
+++ b/cmd/yggd/worker.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"git.sr.ht/~spc/go-log"
+	"github.com/redhatinsights/yggdrasil"
+	"github.com/rjeczalik/notify"
+)
+
+func killWorker(pidFile string) error {
+	data, err := os.ReadFile(pidFile)
+	if err != nil {
+		return fmt.Errorf("cannot read contents of file: %w", err)
+	}
+	pid, err := strconv.ParseInt(string(data), 10, 64)
+	if err != nil {
+		return fmt.Errorf("cannot parse file contents as int: %w", err)
+	}
+
+	if err := killProcess(int(pid)); err != nil {
+		return fmt.Errorf("cannot kill process: %w", err)
+	}
+
+	if err := os.Remove(pidFile); err != nil {
+		return fmt.Errorf("cannot remove file: %w", err)
+	}
+	return nil
+}
+
+func killWorkers() error {
+	pidDirPath := filepath.Join(yggdrasil.LocalstateDir, "run", yggdrasil.LongName, "workers")
+	if err := os.MkdirAll(pidDirPath, 0755); err != nil {
+		return fmt.Errorf("cannot create directory: %w", err)
+	}
+	fileInfos, err := os.ReadDir(pidDirPath)
+	if err != nil {
+		return fmt.Errorf("cannot read contents of directory: %w", err)
+	}
+
+	for _, info := range fileInfos {
+		pidFilePath := filepath.Join(pidDirPath, info.Name())
+		if err := killWorker(pidFilePath); err != nil {
+			return fmt.Errorf("cannot kill worker: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func watchWorkerDir(dir string, env []string, died chan int) {
+	c := make(chan notify.EventInfo, 1)
+
+	if err := notify.Watch(dir, c, notify.InCloseWrite, notify.InDelete, notify.InMovedFrom, notify.InMovedTo); err != nil {
+		log.Errorf("cannot start notify watchpoint: %v", err)
+		return
+	}
+	defer notify.Stop(c)
+
+	for e := range c {
+		log.Debugf("received inotify event %v", e.Event())
+		switch e.Event() {
+		case notify.InCloseWrite, notify.InMovedTo:
+			if strings.HasSuffix(e.Path(), "worker") {
+				if ExcludeWorkers[filepath.Base(e.Path())] {
+					continue
+				}
+				log.Tracef("new worker detected: %v", e.Path())
+				go startProcess(e.Path(), env, 0, died)
+			}
+		case notify.InDelete, notify.InMovedFrom:
+			workerName := filepath.Base(e.Path())
+			pidFilePath := filepath.Join(
+				yggdrasil.LocalstateDir,
+				"run",
+				yggdrasil.LongName,
+				"workers",
+				workerName+".pid",
+			)
+
+			if err := killWorker(pidFilePath); err != nil {
+				log.Errorf("cannot kill worker: %v", err)
+				continue
+			}
+		}
+	}
+}

--- a/cmd/yggd/worker_test.go
+++ b/cmd/yggd/worker_test.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+)
+
+func TestValidEnvVar(t *testing.T) {
+	tests := []struct {
+		description string
+		input       string
+		want        bool
+	}{
+		{
+			description: "invalid: PATH",
+			input:       "PATH=/opt/bin:$PATH",
+			want:        false,
+		},
+		{
+			description: "valid: HTTP_PROXY",
+			input:       "HTTP_PROXY=http://localhost:8080",
+			want:        true,
+		},
+		{
+			description: "invalid: YGG_SOCKET_ADDR",
+			input:       "YGG_SOCKET_ADDR=@yggd",
+			want:        false,
+		},
+		{
+			description: "valid: YGGD_VERSION",
+			input:       "YGGD_VERSION=1.2.3",
+			want:        true,
+		},
+		{
+			description: "invalid: YGG_VERSION",
+			input:       "YGG_VERSION=1.2.3",
+			want:        false,
+		},
+		{
+			description: "invalid: YGG_=",
+			input:       "YGG_=",
+			want:        false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			got := validEnvVar(test.input)
+
+			if !cmp.Equal(got, test.want) {
+				t.Errorf("%#v != %#v", got, test.want)
+			}
+		})
+	}
+}
+
+func TestStartWorker(t *testing.T) {
+	tests := []struct {
+		description string
+		input       workerConfig
+		want        string
+		wantError   error
+	}{
+		{
+			input: workerConfig{
+				Env:     []string{},
+				delay:   0,
+				program: "/usr/bin/echo",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			err := startWorker(test.input, nil, nil)
+
+			if test.wantError != nil {
+				if !cmp.Equal(err, test.wantError, cmpopts.EquateErrors()) {
+					t.Errorf("%#v != %#v", err, test.wantError)
+				}
+			} else {
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR refactors the way processes are started, watched, killed, and restarted. The routines in `exec.go` were a mixture of higher-level worker process management (including restart delays, PID file management, etc.) and lower-level process start and kill routines. This PR moves the higher-level logic out of `exec.go` and into a file called `worker.go`. The routines in `exec.go` are now purely lower-level routines that start and stop processes; they have no awareness of worker configuration or process restart management (`startProcess`, `stopProcess`, `waitProcess`). The functions in `worker.go` operate on a `workerConfig` data structure to start, stop and manage workers.

A `workerConfig` structure is created by parsing an optional configuration file that must be defined in `/etc/yggdrasil/workers`. This configuration file, if present when a worker is started, is loaded. The 'env' field of the configuration file is parsed as a string slice. Elements of this slice must be in the form of a "VAR=VALUE" string, and are inserted into the worker process's environment before starting. It is forbidden to set PATH or any variable beginning with YGG_ in a worker's configuration file. Any variables by these names will be omitted when starting the worker process.

A worker's environment is automatically configured with a reasonable base PATH value (`/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin`) and inherits values from its parent for: `http_proxy`, `HTTP_PROXY`, `HTTPS_PROXY`, `ALL_PROXY`, and `NO_PROXY`.

