### PR TITLE
Allow hyphenated names, with a warning

### DIFF
--- a/cmd/yggd/client.go
+++ b/cmd/yggd/client.go
@@ -357,6 +357,12 @@ func (c *Client) ReceiveControlMessage(msg *yggdrasil.Control) error {
 			if !exists {
 				return fmt.Errorf("cancel command does not contain 'messageID' argument")
 			}
+
+			directive, err := work.ScrubName(directive)
+			if err != nil {
+				log.Debug(err)
+			}
+
 			// Dispatch to appropriate worker.
 			if err := c.dispatcher.CancelMessage(directive, msg.MessageID, cancelID); err != nil {
 				return fmt.Errorf("cannot dispatch cancel message: %w", err)

--- a/internal/work/dbus.go
+++ b/internal/work/dbus.go
@@ -1,6 +1,11 @@
 package work
 
-import "github.com/godbus/dbus/v5"
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/godbus/dbus/v5"
+)
 
 func NewDBusError(name string, body ...string) *dbus.Error {
 	e := dbus.Error{}
@@ -9,4 +14,17 @@ func NewDBusError(name string, body ...string) *dbus.Error {
 		e.Body = append(e.Body, v)
 	}
 	return &e
+}
+
+// ScrubName cleans up invalid bus names to ensure D-Bus name specification
+// conformance. An error is returned along with the scrubbed value if the name
+// contained invalid characters.
+func ScrubName(name string) (string, error) {
+	r := regexp.MustCompile("-")
+	if r.Match([]byte(name)) {
+		return string(
+			r.ReplaceAll([]byte(name), []byte("_")),
+		), fmt.Errorf("invalid worker name: %v", name)
+	}
+	return name, nil
 }

--- a/internal/work/dbus_test.go
+++ b/internal/work/dbus_test.go
@@ -1,0 +1,61 @@
+package work
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+)
+
+func TestScrubName(t *testing.T) {
+	tests := []struct {
+		description string
+		input       string
+		want        string
+		wantError   error
+	}{
+		{
+			description: "no hyphens",
+			input:       "alpha",
+			want:        "alpha",
+		},
+		{
+			description: "single hyphen",
+			input:       "alpha-bravo",
+			want:        "alpha_bravo",
+			wantError:   cmpopts.AnyError,
+		},
+		{
+			description: "multiple hyphens",
+			input:       "alpha-bravo-charlie",
+			want:        "alpha_bravo_charlie",
+			wantError:   cmpopts.AnyError,
+		},
+		{
+			description: "consecutive hyphens",
+			input:       "alpha--bravo",
+			want:        "alpha__bravo",
+			wantError:   cmpopts.AnyError,
+		},
+		{
+			description: "mixed",
+			input:       "alpha_bravo-charlie",
+			want:        "alpha_bravo_charlie",
+			wantError:   cmpopts.AnyError,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			got, err := ScrubName(test.input)
+
+			if !cmp.Equal(got, test.want) {
+				t.Errorf("%v", cmp.Diff(got, test.want))
+			}
+
+			if !cmp.Equal(err, test.wantError, cmpopts.EquateErrors()) {
+				t.Errorf("%#v != %#v", err, test.wantError)
+			}
+		})
+	}
+}

--- a/internal/work/dispatcher.go
+++ b/internal/work/dispatcher.go
@@ -193,6 +193,12 @@ func (d *Dispatcher) Connect() error {
 }
 
 func (d *Dispatcher) Dispatch(data yggdrasil.Data) error {
+	var err error
+	data.Directive, err = ScrubName(data.Directive)
+	if err != nil {
+		log.Debug(err)
+	}
+
 	obj := d.conn.Object(
 		"com.redhat.Yggdrasil1.Worker1."+data.Directive,
 		dbus.ObjectPath(filepath.Join("/com/redhat/Yggdrasil1/Worker1/", data.Directive)),


### PR DESCRIPTION
The D-Bus name specification does not allow hyphens (-) in names or paths. Workers should really switch to using compliant names. However, in order to maintain compatibility with existing services, when a message is received for a worker, the name is passed through a scrubbing function that cleans up the name. As of this PR, this scrub function replaces hyphens with underscores and returns an error. This error is then logged. These log messages should hopefully encourage service authors to switch to using compatible names.

Closes: #210