### PR TITLE
feat: Try to run yggd as non-root user using systemd benefits

### DIFF
--- a/data/dbus/yggd.conf
+++ b/data/dbus/yggd.conf
@@ -4,7 +4,7 @@
  "-//freedesktop//DTD D-BUS Bus Configuration 1.0//EN"
  "https://dbus.freedesktop.org/doc/busconfig.dtd">
 <busconfig>
-  <policy user="root">
+  <policy user="yggd">
     <!-- Only root can own the Dispatcher1 and Worker1.* destination names. -->
     <allow own="com.redhat.Yggdrasil1.Dispatcher1"/>
     <allow own_prefix="com.redhat.Yggdrasil1.Worker1"/>

--- a/data/systemd/yggdrasil.service.in
+++ b/data/systemd/yggdrasil.service.in
@@ -11,6 +11,11 @@ NotifyAccess=main
 WatchdogSec=300
 ExecStart=@bindir@/yggd
 PrivateTmp=true
+ExecStartPre=/bin/mkdir -p -m 740 /var/lib/yggdrasil
+ExecStartPre=/bin/chown -R yggd:yggd /var/lib/yggdrasil
+User=yggd
+Group=yggd
+DynamicUser=true
 
 [Install]
 WantedBy=multi-user.target

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -44,7 +44,10 @@ var (
 )
 
 func init() {
-	if os.Getuid() > 0 {
+	// User with UID == 0 is root. Users with UID in range 1..999
+	// are system users. More information about UIDs and GIDs
+	// could be found e.g. here: https://systemd.io/UIDS-GIDS/
+	if os.Getuid() >= 1000 {
 		ConfigDir = filepath.Join(xdg.ConfigHome, "yggdrasil")
 		StateDir = filepath.Join(xdg.StateHome, "yggdrasil")
 		CacheDir = filepath.Join(xdg.CacheHome, "yggdrasil")

--- a/worker/echo/com.redhat.Yggdrasil1.Worker1.echo.conf
+++ b/worker/echo/com.redhat.Yggdrasil1.Worker1.echo.conf
@@ -1,13 +1,36 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!DOCTYPE busconfig PUBLIC
- "-//freedesktop//DTD D-BUS Bus Configuration 1.0//EN"
- "https://dbus.freedesktop.org/doc/busconfig.dtd">
- <busconfig>
- <policy user="root">
-    <!-- Only root can send messages to the Worker1.echo destination. -->
-    <allow send_destination="com.redhat.Yggdrasil1.Worker1.echo" send_interface="com.redhat.Yggdrasil1.Worker1"/>
-    <allow send_destination="com.redhat.Yggdrasil1.Worker1.echo" send_interface="org.freedesktop.DBus.Properties"/>
-    <allow send_destination="com.redhat.Yggdrasil1.Worker1.echo" send_interface="org.freedesktop.DBus.Introspectable"/>
-</policy>
+  "-//freedesktop//DTD D-BUS Bus Configuration 1.0//EN"
+  "https://dbus.freedesktop.org/doc/busconfig.dtd">
+  <busconfig>
+  <policy user="echo_worker">
+    <allow own="com.redhat.Yggdrasil1.Worker1.echo"/>
+
+    <!--
+    Only service user echo_worker can send messages to the Worker1.echo destination.
+    -->
+    <allow send_destination="com.redhat.Yggdrasil1.Worker1.echo"
+      send_interface="com.redhat.Yggdrasil1.Worker1"/>
+  </policy>
+
+  <policy user="yggd">
+    <!--
+    The service user "yggd" used for running yggd service has to be able
+    to call Dispatch D-Bus method.
+    -->
+    <allow send_destination="com.redhat.Yggdrasil1.Worker1.echo"
+      send_interface="com.redhat.Yggdrasil1.Worker1"
+      send_member="Dispatch"/>
+
+    <!-- Only yggd can read properties of worker -->
+    <allow send_destination="com.redhat.Yggdrasil1.Worker1.echo"
+       send_interface="org.freedesktop.DBus.Properties"/>
+  </policy>
+
+  <policy context="default">
+    <!-- Everybody should be able to introspect D-Bus API of echo worker -->
+    <allow send_destination="com.redhat.Yggdrasil1.Worker1.echo"
+      send_interface="org.freedesktop.DBus.Introspectable"/>
+  </policy>
 </busconfig>

--- a/worker/echo/com.redhat.Yggdrasil1.Worker1.echo.service.in
+++ b/worker/echo/com.redhat.Yggdrasil1.Worker1.echo.service.in
@@ -1,4 +1,6 @@
 [D-BUS Service]
 Name=com.redhat.Yggdrasil1.Worker1.echo
-User=root
+User=echo_worker
+Group=ygg_worker
+DynamicUser=true
 Exec=@libexecdir@/yggdrasil/echo


### PR DESCRIPTION
* It is unsuccessful attempt to run yggd as non-root user ussing benefits of systemd. It is not possible to create /var/lib/yggdrassil directory and the client-id file using ExecStartPre, because systemd probably tries to run given command using yggd user, which could not work. Another option could be creating this directory in RPM post installation script (spec file), but we should also consider updating of file and could not solve the case, when file is just created manually by root. We should also create yggd user during installation of yggdrasil RPM.