### PR TITLE
Specify targets in main-branch job

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -41,3 +41,9 @@ jobs:
     branch: main
     owner: "@yggdrasil"
     project: latest
+    targets:
+      - centos-stream-8
+      - centos-stream-9
+      - fedora-all
+      - rhel-8
+      - rhel-9


### PR DESCRIPTION
Specify the list of targets to build in the 'main' COPR job. Hopefully this eliminates the behavior of Packit creating a separate COPR build for each buildroot/architecture pair in the project's enabled buildroots.