### PR TITLE
Rename "canonical-facts" flag

### DIFF
--- a/cmd/yggd/client.go
+++ b/cmd/yggd/client.go
@@ -376,13 +376,13 @@ func (c *Client) ReceiveControlMessage(msg *yggdrasil.Control) error {
 func (c *Client) ConnectionStatus() (*yggdrasil.ConnectionStatus, error) {
 	var facts map[string]interface{}
 
-	if config.DefaultConfig.CanonicalFacts != "" {
-		data, err := os.ReadFile(config.DefaultConfig.CanonicalFacts)
+	if config.DefaultConfig.FactsFile != "" {
+		data, err := os.ReadFile(config.DefaultConfig.FactsFile)
 		if err != nil {
-			log.Errorf("cannot read canonical facts file: %v", err)
+			log.Errorf("cannot read facts file: %v", err)
 		}
 		if err := json.Unmarshal(data, &facts); err != nil {
-			log.Errorf("cannot unmarshal canonical facts: %v", err)
+			log.Errorf("cannot unmarshal facts: %v", err)
 		}
 	}
 

--- a/cmd/yggd/main.go
+++ b/cmd/yggd/main.go
@@ -60,7 +60,7 @@ func setupDefaultConfig(c *cli.Context) {
 		PathPrefix:               c.String(config.FlagNamePathPrefix),
 		Protocol:                 c.String(config.FlagNameProtocol),
 		DataHost:                 c.String(config.FlagNameDataHost),
-		CanonicalFacts:           c.String(config.FlagNameCanonicalFacts),
+		FactsFile:                c.String(config.FlagNameFactsFile),
 		HTTPRetries:              c.Int(config.FlagNameHTTPRetries),
 		HTTPTimeout:              c.Duration(config.FlagNameHTTPTimeout),
 		MQTTConnectRetry:         c.Bool(config.FlagNameMQTTConnectRetry),
@@ -221,14 +221,14 @@ func publishConnectionStatus(client *Client) {
 	}
 }
 
-// monitorCanonicalFacts tries to monitor canonical facts file for changes
-func monitorCanonicalFacts(client *Client) {
-	if config.DefaultConfig.CanonicalFacts == "" {
+// monitorFactsFile tries to monitor facts file for changes
+func monitorFactsFile(client *Client) {
+	if config.DefaultConfig.FactsFile == "" {
 		return
 	}
 	c := make(chan notify.EventInfo, 1)
-	if err := notify.Watch(config.DefaultConfig.CanonicalFacts, c, notify.InCloseWrite); err != nil {
-		log.Infof("cannot start watching '%v': %v", config.DefaultConfig.CanonicalFacts, err)
+	if err := notify.Watch(config.DefaultConfig.FactsFile, c, notify.InCloseWrite); err != nil {
+		log.Infof("cannot start watching '%v': %v", config.DefaultConfig.FactsFile, err)
 		return
 	}
 	defer notify.Stop(c)
@@ -400,9 +400,9 @@ func mainAction(c *cli.Context) error {
 	// Publish connection-status in a goroutine
 	go publishConnectionStatus(client)
 
-	// Start a goroutine watching for changes to the CanonicalFacts file and
-	// publish a new connection-status message if the file changes.
-	go monitorCanonicalFacts(client)
+	// Start a goroutine watching for changes to the facts file and publish a
+	// new connection-status message if the file changes.
+	go monitorFactsFile(client)
 
 	// Start a goroutine that watches the tags file for write events and
 	// publishes connection status messages when the file changes.
@@ -513,8 +513,8 @@ func main() {
 			Usage: "Use `VALUE` as the client ID when connecting",
 		}),
 		altsrc.NewPathFlag(&cli.PathFlag{
-			Name:      config.FlagNameCanonicalFacts,
-			Usage:     "Read canonical facts from `FILE`",
+			Name:      config.FlagNameFactsFile,
+			Usage:     "Read facts from `FILE`",
 			TakesFile: true,
 		}),
 		altsrc.NewIntFlag(&cli.IntFlag{

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -21,7 +21,7 @@ const (
 	FlagNamePathPrefix               = "path-prefix"
 	FlagNameProtocol                 = "protocol"
 	FlagNameDataHost                 = "data-host"
-	FlagNameCanonicalFacts           = "canonical-facts"
+	FlagNameFactsFile                = "facts-file"
 	FlagNameHTTPRetries              = "http-retries"
 	FlagNameHTTPTimeout              = "http-timeout"
 	FlagNameMQTTConnectRetry         = "mqtt-connect-retry"
@@ -72,9 +72,9 @@ type Config struct {
 	// handling data retrieval for "detachedContent" workers.
 	DataHost string
 
-	// CanonicalFacts is a path to a JSON file containing "canonical facts",
-	// a set of facts about the system used to uniquely identify it.
-	CanonicalFacts string
+	// FactsFile is a path to a file containing a JSON object consisting of
+	// key/value pairs that can be used for system identification.
+	FactsFile string
 
 	// HTTPRetries is the number of times the client will attempt to resend
 	// failed HTTP requests before giving up.


### PR DESCRIPTION
The notion of "canonical facts" is unique to Red Hat Insights. However,
the idea of transmitting a set of facts about a system upon connection
is generic enough that it can still exist as an option in yggd. This
commit renames the "canonical-facts" flag, config value and related
variables to "facts-file" to more accurate reflect what it expects (a
file) and to be generic enough to accept any set of "facts" about the
system.

Notably, this commit *does not* rename the "canonical_facts" JSON field
in the "connection-status" message; that field name is part of the
agreed JSON schema in the message protocol, so changing that field would
require breaking the protocol. The protocol does have a mechanism for
such a situation; the "version" field of a message can be incremented.
However, for now, I left the field unmodified.