### PR TITLE
Add dist workflow

### DIFF
--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -1,0 +1,20 @@
+name: dist
+
+on:
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "stable"
+      - run: sudo apt-get update && sudo apt-get install -y libdbus-1-dev meson
+      - run: meson setup -Dvendor=True _build && meson dist -C _build
+      - uses: softprops/action-gh-release@v2
+        with:
+          files: _build/meson-dist/yggdrasil-*.tar.xz


### PR DESCRIPTION
With this workflow, when a new git tag is created using the semantic versioning syntax (vX.Y.Z), this workflow checkout the tag from git, generates a `yggdrasil-X.Y.Z.tar.xz` and attaches it as an asset to the release.

[Here's an example](https://github.com/subpop/yggdrasil/actions/runs/9197368705/job/25297639408) of the workflow running on my fork.