### PR TITLE
Correct echo worker D-Bus policy permissions

### DIFF
--- a/worker/echo/dbus/com.redhat.Yggdrasil1.Worker1.echo.conf.in
+++ b/worker/echo/dbus/com.redhat.Yggdrasil1.Worker1.echo.conf.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE busconfig PUBLIC "-//freedesktop//DTD D-BUS Bus Configuration 1.0//EN" "https://dbus.freedesktop.org/doc/busconfig.dtd">
 <busconfig>
-    <policy user="@worker_user@">
+    <policy group="@worker_user@">
         <!-- Only @worker_user@ can own the Worker1.echo name. -->
         <allow own="com.redhat.Yggdrasil1.Worker1.echo" />
 

--- a/worker/echo/dbus/com.redhat.Yggdrasil1.Worker1.echo.service.in
+++ b/worker/echo/dbus/com.redhat.Yggdrasil1.Worker1.echo.service.in
@@ -1,3 +1,3 @@
 [D-BUS Service]
 Name=com.redhat.Yggdrasil1.Worker1.echo
-Exec=@libexecdir@/yggdrasil/echo
+SystemdService=com.redhat.Yggdrasil1.Worker1.echo.service


### PR DESCRIPTION
The recent changes to allow `yggd` and workers to run as non-root users involved making change to the D-Bus access policies. The D-Bus policy for the echo worker installed a policy that only permitted the user "yggdrasil-worker" to send messages on the bus. This created an issue where `yggd` could not send messages to the echo worker.

## Steps to Reproduce

Optionally increase the `log-level` in `/etc/yggdrasil/config.toml` to a higher value if you want to observe more logging output. Using a network transport for message dispatch is not necessary to reproduce this, so you can optionally disable the network transport by setting `protocol` to `"none"`.

1. Start `yggd`: `sudo systemctl start yggdrasil`
2. In a second terminal, run `sudo yggctl listen -w echo` to observe whether the message is received
3. Send a message to the echo worker: `echo '"hello"' | sudo yggctl dispatch -w echo -`

## Actual Results

D-Bus attempts to start the service through its service activation policy, but fails to do so:

```
cannot dispatch message: cannot dispatch to directive: cannot get property 'com.redhat.Yggdrasil1.Worker1.RemoteContent': Could not activate remote peer 'com.redhat.Yggdrasil1.Worker1.echo': unit failed
```

## Expected Results

The service should be started by the D-Bus daemon when a message is sent to the name `com.redhat.Yggdrasil1.Worker1.echo`.

```
Dispatched message 898d312e-b0ee-4fc8-b95b-3b3e1e6de479 to worker echo
```

## Notes

This bug should also occur if you manually start the `com.redhat.Yggdrasil1.Worker1.echo` systemd unit before sending the worker data.

## Fix

This PR includes two commits. The first adjusts the D-Bus policy so that members of the `worker_user` group can own and send messages to `com.redhat.Yggdrasil1.Worker1.echo`. This fixes the actual transmitting of message data through the bus. The second commit applies a fix to the D-Bus service file, correctly configuring it to use the systemd service `com.redhat.Yggdrasil1.Worker1.echo` instead of creating a dynamic unit.