### PR TITLE
Include CentOS Stream 10 when building with packit

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -32,6 +32,7 @@ jobs:
     targets:
       - centos-stream-8
       - centos-stream-9
+      - centos-stream-10
       - fedora-all
       - rhel-8
       - rhel-9
@@ -44,6 +45,7 @@ jobs:
     targets:
       - centos-stream-8
       - centos-stream-9
+      - centos-stream-10
       - fedora-all
       - rhel-8
       - rhel-9
@@ -54,6 +56,7 @@ jobs:
     targets:
       - centos-stream-8
       - centos-stream-9
+      - centos-stream-10
     labels:
       - unit
 

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -31,11 +31,16 @@ jobs:
       - "copr://@yggdrasil/latest"
     targets:
       - centos-stream-8
-      - centos-stream-9
-      - centos-stream-10
-      - fedora-all
-      - rhel-8
-      - rhel-9
+      - centos-stream-9-aarch64
+      - centos-stream-9-x86_64
+      - centos-stream-10-aarch64
+      - centos-stream-10-x86_64
+      - fedora-all-aarch64
+      - fedora-all-x86_64
+      - rhel-8-aarch64
+      - rhel-8-x86_64
+      - rhel-9-aarch64
+      - rhel-9-x86_64
 
   - job: copr_build
     trigger: commit
@@ -44,19 +49,26 @@ jobs:
     project: latest
     targets:
       - centos-stream-8
-      - centos-stream-9
-      - centos-stream-10
-      - fedora-all
-      - rhel-8
-      - rhel-9
+      - centos-stream-9-aarch64
+      - centos-stream-9-x86_64
+      - centos-stream-10-aarch64
+      - centos-stream-10-x86_64
+      - fedora-all-aarch64
+      - fedora-all-x86_64
+      - rhel-8-aarch64
+      - rhel-8-x86_64
+      - rhel-9-aarch64
+      - rhel-9-x86_64
 
   - job: tests
     trigger: pull_request
     identifier: "unit/centos-stream"
     targets:
       - centos-stream-8
-      - centos-stream-9
-      - centos-stream-10
+      - centos-stream-9-aarch64
+      - centos-stream-9-x86_64
+      - centos-stream-10-aarch64
+      - centos-stream-10-x86_64
     labels:
       - unit
 
@@ -72,9 +84,15 @@ jobs:
     trigger: pull_request
     identifier: "unit/rhel"
     targets:
+      rhel-8-aarch64:
+        distros:
+          - RHEL-8-Nightly
       rhel-8-x86_64:
         distros:
           - RHEL-8-Nightly
+      rhel-9-aarch64:
+        distros:
+          - RHEL-9-Nightly
       rhel-9-x86_64:
         distros:
           - RHEL-9-Nightly


### PR DESCRIPTION
Include CentOS Stream 10 buildroots in COPR. Additionally, explicitly build both x86_64 and aarch64 packages.