### PR TITLE
feat(yggctl): add generate worker-data command

### DIFF
--- a/cmd/yggctl/templates.go
+++ b/cmd/yggctl/templates.go
@@ -1,0 +1,47 @@
+package main
+
+var DBusServiceTemplate = `[D-BUS Service]
+Name=com.redhat.Yggdrasil1.Worker1.{{ .Name }}
+SystemdService=com.redhat.Yggdrasil1.Worker1.{{ .Name }}.Service
+`
+
+var DBusPolicyConfigTemplate = `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE busconfig PUBLIC "-//freedesktop//DTD D-BUS Bus Configuration 1.0//EN" "https://dbus.freedesktop.org/doc/busconfig.dtd">
+<busconfig>
+    <policy group="{{ .Group }}">
+        <!-- Only {{ .Group }} can own the Worker1.{{ .Name }} name. -->
+        <allow own="com.redhat.Yggdrasil1.Worker1.{{ .Name }}" />
+
+        <!-- Only {{ .Group }} can send messages to the Worker1 interface. -->
+        <allow send_destination="com.redhat.Yggdrasil1.Worker1.{{ .Name }}"
+            send_interface="com.redhat.Yggdrasil1.Worker1" />
+
+        <!-- Only {{ .Group }} can send messages to the Properties interface. -->
+        <allow send_destination="com.redhat.Yggdrasil1.Worker1.{{ .Name }}"
+            send_interface="org.freedesktop.DBus.Properties" />
+
+        <!-- Only {{ .Group }} can send messages to the Introspectable interface. -->
+        <allow send_destination="com.redhat.Yggdrasil1.Worker1.{{ .Name }}"
+            send_interface="org.freedesktop.DBus.Introspectable" />
+
+        <!-- Only {{ .Group }} can send messages to the Peer interface. -->
+        <allow send_destination="com.redhat.Yggdrasil1.Worker1.{{ .Name }}"
+            send_interface="org.freedesktop.DBus.Peer" />
+    </policy>
+</busconfig>
+`
+
+var SystemdServiceTemplate = `[Unit]
+Description=yggdrasil {{ .Name }} worker service
+Documentation=https://github.com/RedHatInsights/yggdrasil
+
+[Service]
+Type=dbus
+User={{ .User }}
+Group={{ .Group }}
+ExecStart={{ .Program }}
+BusName=com.redhat.Yggdrasil1.Worker1.{{ .Name }}
+
+[Install]
+WantedBy=multi-user.target
+`

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -26,6 +26,8 @@ var (
 	PrefixDir     string = filepath.Join("/", "usr", "local")
 	SysconfDir    string = filepath.Join(PrefixDir, "etc")
 	LocalstateDir string = filepath.Join(PrefixDir, "var")
+	DataDir       string = filepath.Join(PrefixDir, "share")
+	LibDir        string = filepath.Join(PrefixDir, "lib")
 
 	// ConfigDir is a path to a location where configuration data is assumed to
 	// be stored. For non-root users, this is set to $CONFIGURATION_DIRECTORY or
@@ -42,6 +44,18 @@ var (
 	// $XDG_CACHE_HOME/yggdrasil. Otherwise, it gets set to
 	// /var/cache/yggdrasil.
 	CacheDir string = filepath.Join(LocalstateDir, "cache", "yggdrasil")
+
+	// DBusSystemServicesDir is a path to a location where D-Bus bus-activable
+	// system service definition files are stored.
+	DBusSystemServicesDir string = filepath.Join(DataDir, "dbus-1", "system-services")
+
+	// DBusPolicyConfigDir is a path to a location where D-Bus policy
+	// configuration definition files are stored.
+	DBusPolicyConfigDir string = filepath.Join(DataDir, "dbus-1", "system.d")
+
+	// SystemdSystemServicesDir is a path to a location where systemd system
+	// service unit files are stored.
+	SystemdSystemServicesDir string = filepath.Join(LibDir, "systemd", "system")
 )
 
 func init() {

--- a/meson.build
+++ b/meson.build
@@ -18,6 +18,12 @@ goldflags += ' -X "github.com/redhatinsights/yggdrasil/internal/constants.Defaul
 goldflags += ' -X "github.com/redhatinsights/yggdrasil/internal/constants.PrefixDir=' + get_option('prefix') + '"'
 goldflags += ' -X "github.com/redhatinsights/yggdrasil/internal/constants.SysconfDir=' + get_option('sysconfdir') + '"'
 goldflags += ' -X "github.com/redhatinsights/yggdrasil/internal/constants.LocalstateDir=' + get_option('localstatedir') + '"'
+goldflags += ' -X "github.com/redhatinsights/yggdrasil/internal/constants.DataDir=' + get_option('datadir') + '"'
+goldflags += ' -X "github.com/redhatinsights/yggdrasil/internal/constants.LibDir=' + get_option('libdir') + '"'
+goldflags += ' -X "github.com/redhatinsights/yggdrasil/internal/constants.DBusSystemServicesDir=' + dbus.get_variable(pkgconfig: 'system_bus_services_dir') + '"'
+goldflags += ' -X "github.com/redhatinsights/yggdrasil/internal/constants.DBusPolicyConfigDir=' + join_paths(dbus.get_variable(pkgconfig: 'datadir'), 'dbus-1', 'system.d') + '"'
+goldflags += ' -X "github.com/redhatinsights/yggdrasil/internal/constants.SystemdSystemServicesDir=' + systemd.get_variable(pkgconfig: 'systemdsystemunitdir') + '"'
+
 
 if get_option('default_data_host') != ''
   goldflags += ' -X "github.com/redhatinsights/yggdrasil/internal/constants.DefaultDataHost=' + get_option('default_data_host') + '"'


### PR DESCRIPTION
The generate worker-data command creates files relevant to D-Bus and systemd in order for a worker to communicate with yggd. This is intended to make worker development easier; if a worker has a relatively standard startup and policy configuration, it can be configured to invoke this subcommand instead of keeping the files in its own source repository.

The files can either be installed directly by specifying the --install flag, or they can be written to a given output directory.

The --user, --program and --name flags must be included in the invocation. For example:

```
yggctl generate worker-data \
  --name echo \
  --program /usr/libexec/yggdrasil/echo \
  --user $(pkgconf yggdrasil --variable worker_user \
  --install
```

Card ID: CCT-680