### PR TITLE
fix(systemd): add Alias for yggd.service

### DIFF
--- a/data/systemd/system/yggdrasil.service.in
+++ b/data/systemd/system/yggdrasil.service.in
@@ -18,3 +18,4 @@ CacheDirectory=yggdrasil
 
 [Install]
 WantedBy=multi-user.target
+Alias=yggd.service


### PR DESCRIPTION
Older versions of yggdrasil shipped a service named yggd.service. Adding
an alias directive with this value eases
the migration/upgrading from older versions of yggdrasil.