### PR TITLE
Collect workers immediately

### DIFF
--- a/cmd/yggctl/actions.go
+++ b/cmd/yggctl/actions.go
@@ -201,12 +201,6 @@ func workersAction(c *cli.Context) error {
 			}
 			_ = writer.Flush()
 		}
-	case "text":
-		for worker, features := range workers {
-			for field, value := range features {
-				fmt.Printf("%v - %v: %v\n", worker, field, value)
-			}
-		}
 	default:
 		return cli.Exit(fmt.Errorf("unknown format type: %v", c.String("format")), 1)
 	}

--- a/cmd/yggctl/actions.go
+++ b/cmd/yggctl/actions.go
@@ -194,11 +194,13 @@ func workersAction(c *cli.Context) error {
 		fmt.Println(string(data))
 	case "table":
 		writer := tabwriter.NewWriter(os.Stdout, 4, 4, 2, ' ', 0)
-		fmt.Fprintf(writer, "WORKER\tFIELD\tVALUE\n")
+		fmt.Fprintf(writer, "WORKER\tFEATURES\n")
 		for worker, features := range workers {
-			for field, value := range features {
-				fmt.Fprintf(writer, "%v\t%v\t%v\n", worker, field, value)
+			featureSummary, err := json.Marshal(features)
+			if err != nil {
+				return cli.Exit(fmt.Errorf("cannot marshal features: %v", err), 1)
 			}
+			fmt.Fprintf(writer, "%v\t%v\n", worker, string(featureSummary))
 			_ = writer.Flush()
 		}
 	default:

--- a/cmd/yggctl/main.go
+++ b/cmd/yggctl/main.go
@@ -179,8 +179,8 @@ communicate properly with yggd.`,
 					Flags: []cli.Flag{
 						&cli.StringFlag{
 							Name:  "format",
-							Usage: "Print output in `FORMAT` (json, table or text)",
-							Value: "text",
+							Usage: "Print output in `FORMAT` (json or table)",
+							Value: "table",
 						},
 					},
 					Action: workersAction,

--- a/cmd/yggd/util.go
+++ b/cmd/yggd/util.go
@@ -7,12 +7,7 @@ import (
 	"math/rand"
 	"os"
 	"path/filepath"
-	"time"
 )
-
-func init() {
-	rand.Seed(time.Now().UnixNano())
-}
 
 func randomString(n int) string {
 	const letters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"

--- a/internal/work/dispatcher.go
+++ b/internal/work/dispatcher.go
@@ -130,9 +130,8 @@ func (d *Dispatcher) Connect() error {
 			case "org.freedesktop.DBus.Properties.PropertiesChanged":
 				changedProperties, ok := s.Body[1].(map[string]dbus.Variant)
 				if !ok {
-					log.Errorf(
-						"cannot convert body element 1 (changed_properties) to map[string]dbus.Variant: %v",
-						err,
+					log.Error(
+						"cannot convert body element 1 (changed_properties) to map[string]dbus.Variant",
 					)
 					continue
 				}


### PR DESCRIPTION
The current implementation of `yggd` could be described as "lazy discovery of workers"; a worker is only discovered when a message arrives destined for it and the message is routed. If and only if `yggd` is able to successfully deliver a message to a worker, is it then added to the dispatchers table, triggering a publish of an updated "connection-status" message. This lazy-loading causes `yggctl` to output incorrect worker status under certain conditions. If `yggctl workers list` is run immediately after starting `yggd`, the list will be empty.

This PR changes the procedure `yggd` uses to detect and collect workers. After connecting to the bus (in the `(Dispatcher).Connect` method), a goroutine is run that scans the list of names on the bus, collecting any that begin with "com.redhat.Yggdrasil1.Worker1". After the workers are found, a "connection-status" message is published.

Additionally, a MatchSignal is added that watches for name ownership change (specifically the `org.freedesktop.DBus.NameOwnerChanged` signal) within the "com.redhat.Yggdrasil1.Worker1" namespace. If name ownership changes occur, the features are deleted or updated, causing a new "connection-status" message to publish.

I also discovered a related bug in the table and text output formats. If a worker had an empty "features" map, the "text" and "table" would erroneously omit those workers from the output because output was based on a for-loop over the features map. I chose to drop the "text" output format entirely, since it's functionally identical to "table". I also reformatted how the features map is included in the table output.

#### Old

```
WORKER  FIELD         VALUE
echo    DispatchedAt
echo    Version       1
```

#### New

```
WORKER  FEATURES
echo    {"DispatchedAt":"","Version":"1"}
```

Fixes: #135
Card ID: CCT-115