### PR TITLE
feat: Add yggdrasil user to supplementary group rhsm

### DIFF
--- a/dist/srpm/yggdrasil.sysuser.in
+++ b/dist/srpm/yggdrasil.sysuser.in
@@ -2,3 +2,4 @@
 u     @user@          -    "yggdrasil system user" @sharedstatedir@/yggdrasil -
 u     @worker_user@   -    "yggdrasil worker user" -                          -
 m     @user@          @worker_user@
+m     @user@          rhsm


### PR DESCRIPTION
* System user yggdrasil (@user@) is added to supplementary group rhsm. This allows yggdrasil running as non-root user read consumer certificate and key (/etc/pki/consumer/*.pem).
* When `rhsm` group does not exists, then it is automatically created.