### PR TITLE
Log HTTP response from client requests

### DIFF
--- a/internal/http/client.go
+++ b/internal/http/client.go
@@ -107,6 +107,8 @@ func (c *Client) Do(req *http.Request) (*http.Response, error) {
 			}
 		}
 
+		log.Debugf("received HTTP response: %v", resp)
+
 		return resp, nil
 	}
 }


### PR DESCRIPTION
Log the responses received from HTTP requests made by the built-in client. These responses are probably large, so they're logged at the debug level.