### PR TITLE
ci: fix srpm build failures on f41 buildroots

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -3,12 +3,12 @@ downstream_package_name: yggdrasil
 specfile_path: builddir/dist/srpm/yggdrasil.spec
 
 srpm_build_deps:
-  - bash-completion
   - gawk
   - git-core
   - golang
   - go-rpm-macros
   - meson
+  - "pkgconfig(bash-completion)"
   - "pkgconfig(dbus-1)"
   - "pkgconfig(systemd)"
   - rpm-build

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -11,6 +11,7 @@ srpm_build_deps:
   - "pkgconfig(bash-completion)"
   - "pkgconfig(dbus-1)"
   - "pkgconfig(systemd)"
+  - "rpm_macro(autorelease)"
   - rpm-build
 
 actions:

--- a/dist/srpm/yggdrasil.spec.in
+++ b/dist/srpm/yggdrasil.spec.in
@@ -50,7 +50,7 @@ exchanging data with its worker processes through a D-Bus message broker.}
 %global godocs          CONTRIBUTING.md README.md
 
 Name:           yggdrasil
-Release:        0%{?dist}
+Release:        %{?autorelease}%{!?autorelease:0%{?dist}}
 Summary:        Remote data transmission and processing client
 
 License:        GPL-3.0-only


### PR DESCRIPTION
The bash-completion package split the pkgconfig file into a -devel
subpackage in f41. Update the build dependency to use pkgconfig() rather
than explicitly by name.