### PR TITLE
chore: typo fixes

### DIFF
--- a/cmd/yggctl/actions.go
+++ b/cmd/yggctl/actions.go
@@ -386,7 +386,7 @@ func generateWorkerDataAction(ctx *cli.Context) error {
 		}
 		f, err := os.Create(d.FilePath)
 		if err != nil {
-			return cli.Exit(fmt.Errorf("cannt create file %v: %v", d.FilePath, err), 1)
+			return cli.Exit(fmt.Errorf("cannot create file %v: %v", d.FilePath, err), 1)
 		}
 		defer f.Close()
 		if err := d.Template.Execute(f, config); err != nil {

--- a/cmd/yggd/client.go
+++ b/cmd/yggd/client.go
@@ -347,7 +347,7 @@ func (c *Client) ReceiveControlMessage(msg *yggdrasil.Control) error {
 			}
 		case yggdrasil.CommandNameCancel:
 			log.Info("cancelling message...")
-			// Unmarshall comand arguments
+			// Unmarshall command arguments
 			// cmd contains the directive and the message id to be canceled.
 			directive, exists := cmd.Arguments["directive"]
 			if !exists {

--- a/doc/diagrams/yggd-cancel-command.mmd
+++ b/doc/diagrams/yggd-cancel-command.mmd
@@ -9,7 +9,7 @@ S ->> B: data/in {"type":"data","directive":"echo","message-id": "1-1","content"
 B ->> Y: data/in {ditto}
 Y ->> D: Dispatcher method
 D ->>+ W: data/in {ditto}
-Note right of W: echo proccess
+Note right of W: echo process
 W ->> D: Worker Event {Worker:echo Name:BEGIN}
 D ->> Y: Worker Event {Worker:echo Name:BEGIN}
 W ->> D: Worker Event {Worker:echo Name:WORKING}

--- a/doc/diagrams/yggd-data.mmd
+++ b/doc/diagrams/yggd-data.mmd
@@ -9,7 +9,7 @@ S ->> B: data/in {"type":"data","directive":"echo","content":"aGVsbG8="}
 B ->> Y: data/in {ditto}
 Y ->> D: Dispatcher method
 D ->>+ W: data/in {ditto}
-Note right of W: echo proccess
+Note right of W: echo process
 W ->> D: Worker Event {Worker:echo Name:BEGIN}
 D ->> Y: Worker Event {Worker:echo Name:BEGIN}
 W ->> D: Worker Event {Worker:echo Name:WORKING}

--- a/messages.go
+++ b/messages.go
@@ -137,7 +137,7 @@ type WorkerMessage struct {
 }
 
 // Response messages are published by the server as a response to a data
-// message. This is most often used as a receipt to indicate the receiption of a
+// message. This is most often used as a receipt to indicate the reception of a
 // message by a synchronous request/response transport (such as the HTTP polling
 // transport).
 type Response struct {


### PR DESCRIPTION
- "cannt" -> "cannot"
- "comand" -> "command"
- "proccess" -> "process"
- "receiption" -> "reception"