### PR TITLE
build(rpm): Include local state dir

### DIFF
--- a/dist/srpm/yggdrasil.spec.in
+++ b/dist/srpm/yggdrasil.spec.in
@@ -103,6 +103,7 @@ export %gomodulesmode
 %install
 %meson_install
 install -p -D -m 0644 %{SOURCE1} %{buildroot}%{_sysusersdir}/%{name}.conf
+install -d -m 0755 %{buildroot}%{_localstatedir}/lib/yggdrasil
 %if %{has_go_rpm_macros}
 %gopkginstall
 %endif
@@ -144,6 +145,7 @@ install -p -D -m 0644 %{SOURCE1} %{buildroot}%{_sysusersdir}/%{name}.conf
 %{_datadir}/dbus-1/{interfaces,system-services,system.d}/*
 %{_datadir}/doc/%{name}/*
 %{_mandir}/man1/*
+%attr(0755, yggdrasil, yggdrasil) %{_localstatedir}/lib/yggdrasil
 
 %if %{has_go_rpm_macros}
 %gopkgfiles


### PR DESCRIPTION
Include the local state dir in the RPM so that the directory is created
when the package is installed. This enables other services that want to
write to the directory before the yggdrasil service starts.