### PR TITLE
ci: add bash-completion to build deps

### DIFF
--- a/.github/workflows/update-version.yml
+++ b/.github/workflows/update-version.yml
@@ -11,7 +11,7 @@ jobs:
     container:
       image: registry.fedoraproject.org/fedora:latest
     steps:
-      - run: dnf install --setopt install_weak_deps=False --assumeyes golang git-core meson 'pkgconfig(dbus-1)' 'pkgconfig(systemd)' 'rpm_macro(forgemeta)' jq gh
+      - run: dnf install --setopt install_weak_deps=False --assumeyes golang git-core meson 'pkgconfig(bash-completion)' 'pkgconfig(dbus-1)' 'pkgconfig(systemd)' 'rpm_macro(forgemeta)' jq gh
       - uses: actions/checkout@v4
       - run: git config --global safe.directory "*"
       - run: |

--- a/cmd/yggctl/actions.go
+++ b/cmd/yggctl/actions.go
@@ -193,7 +193,7 @@ func workersAction(c *cli.Context) error {
 	// showing both the "legacy" and hyphenated  worker names. Since hyphens in worker
 	// names are disallowed by the D-Bus naming policy it is safe to remove any worker
 	// names with hyphens when listing them.
-	for key, _ := range workers {
+	for key := range workers {
 		if strings.ContainsRune(key, '-') {
 			delete(workers, key)
 		}


### PR DESCRIPTION
Include 'bash-completion' in the list of build dependencies when installing them during 'update-version'.

Card ID: CCT-1089