### PR TITLE
feat: Update go version from 1.18 to 1.22

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/redhatinsights/yggdrasil
 
-go 1.18
+go 1.22
 
 require (
 	git.sr.ht/~spc/go-log v0.1.1


### PR DESCRIPTION
* RHEL9 uses go version 1.22. Thus, I believe it is right time to update go version in go.mod to 1.22
* It seems that it could solve some problems with dependencies