### PR TITLE
feat: Support an empty config file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -111,8 +111,14 @@ sudo go run ./cmd/yggd --server tcp://localhost:1883 --log-level trace --client-
 
 `yggd` can be compiled using meson, or can be run directly with the `go run`
 command. It can read configuration values from a file by running
-`yggd` with the `--config` option. A sample configuration file is included in
-the `data/yggdrasil` directory.
+`yggd` with the `--config` option. If this flag is not specified
+by default the file location, `/etc/yggdrasil/config.toml`, is used.
+A sample configuration file, with all of the lines commented out,
+is included in the the source tree under the `data/yggdrasil`
+directory. This file is installed in the default file location,
+`/etc/yggdrasil/config.toml`.
+To use this sample configuration file uncomment the desired lines and
+run it with the following command:
 
 ```
 sudo go run ./cmd/yggd --config ./data/yggdrasil/config.toml
@@ -144,7 +150,9 @@ port using firewalld, run:
 sudo firewall-cmd --zone public --add-port 2345/tcp --permanent
 ```
 
-Start `dlv` using the `debug` command:
+Start `dlv` using the `debug` command, with the desired lines in
+the sample configuration file commented out, then run it with
+the following command:
 
 ```
 sudo /root/go/bin/dlv debug --api-version 2 --headless --listen 0.0.0.0:2345 \

--- a/README.md
+++ b/README.md
@@ -36,9 +36,11 @@ Configuration of `yggd` can be done by specifying values in a configuration file
 or via command line arguments. Command-line arguments take precedence over
 configuration file values. The configuration file is [TOML](https://toml.io).
 
-The system-wide configuration file is located at `/etc/yggdrasil/config.toml`
-(assuming `SYSCONFDIR=/etc`, as the example above). The location of the file may
-be overridden by passing the `--config` command-line argument to `yggd`.
+The default location searched for the system-wide configuration file is at
+`/etc/yggdrasil/config.toml` (assuming SYSCONFDIR=/etc, as the example above).
+
+The default location of the file may be overridden by passing the `--config`
+command-line argument to `yggd`.
 
 ### (Optional) Authentication
 
@@ -73,6 +75,8 @@ when connecting to the broker. To do this, create the file
 The contents of the file may be any number of TOML key/value pairs. However, a
 limited number of TOML values are accepted as tag values (strings, integers,
 booleans, floats, Local Date, Local Time, Offset Date-Time and Local Date-Time).
+An example the tags.toml file can be found at at
+/usr/share/doc/yggdrasil/tags.toml
 
 ## Running
 

--- a/cmd/yggd/main.go
+++ b/cmd/yggd/main.go
@@ -524,7 +524,7 @@ func main() {
 		altsrc.NewStringFlag(&cli.StringFlag{
 			Name:  config.FlagNameProtocol,
 			Usage: "Transmit data remotely using `PROTOCOL` ('mqtt', 'http' or 'none')",
-			Value: "mqtt",
+			Value: "none",
 		}),
 		altsrc.NewStringSliceFlag(&cli.StringSliceFlag{
 			Name:  config.FlagNameServer,

--- a/data/yggdrasil/config.toml
+++ b/data/yggdrasil/config.toml
@@ -1,5 +1,5 @@
 # yggdrasil global configuration settings
-
-protocol = "mqtt"
-server = ["tcp://test.mosquitto.org:1883"]
-log-level = "error"
+#
+# protocol = "mqtt"
+# server = ["tcp://test.mosquitto.org:1883"]
+# log-level = "error"

--- a/dist/srpm/yggdrasil.spec.in
+++ b/dist/srpm/yggdrasil.spec.in
@@ -107,6 +107,7 @@ export %gomodulesmode
 %meson_install
 install -p -D -m 0644 %{SOURCE1} %{buildroot}%{_sysusersdir}/%{name}.conf
 install -d -m 0755 %{buildroot}%{_localstatedir}/lib/yggdrasil
+install -d -m 0755 %{buildroot}%{_sysconfdir}/yggdrasil
 %if %{has_go_rpm_macros}
 %gopkginstall
 %endif
@@ -148,6 +149,7 @@ install -d -m 0755 %{buildroot}%{_localstatedir}/lib/yggdrasil
 %{_datadir}/dbus-1/{interfaces,system-services,system.d}/*
 %{_datadir}/doc/%{name}/*
 %{_mandir}/man1/*
+%{_sysconfdir}/yggdrasil
 %attr(0755, yggdrasil, yggdrasil) %{_localstatedir}/lib/yggdrasil
 
 %if %{has_go_rpm_macros}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -65,7 +65,7 @@ type Config struct {
 	PathPrefix string
 
 	// Protocol is the protocol used by yggd when connecting to Server. Can be
-	// either MQTT or HTTP.
+	// either MQTT, HTTP or none.
 	Protocol string
 
 	// DataHost is a hostname value to interject into all HTTP requests when


### PR DESCRIPTION
**Card:** CCT-648

### SUMMARY:

This PR supports delivering yggd with fully commented out config file.
and
The hardcoded, default, broker protocol is being changed from mqtt to none.

### CHANGE DETAILS

**_See file(s):_**

-   modified:   internal/config/config.go

A small comment change was made to include the supported values for the broker protocol.

**_See file(s):_**

-   modified:   CONTRIBUTING.md
-   modified:   README.md

The CONTRIBUTING and README pages were updated to reflect the functional changes.

**_See file(s):_**

-   modified:   cmd/yggd/main.go

The hardcoded, default, broker protocol is changed from mqtt to none.

**_See file(s):_**

-   modified: data/yggdrasil/config.toml

The file /etc/yggdrasil/config.toml now contains all commented out lines.

**_See file(s):_**

-   modified:   dist/srpm/yggdrasil.spec.in

This file is updated to specifically create the /etc/yggdrasil directory.

### TESTING:

To test this PR use the RPM from the automated CI/CD build.

**Test 1:** Read the CONTRIBUTING.md and README.md file for clarity and readability.

**Test 2:** Start the yggdrasil service and ensure the new hardcoded default protocol of none is used.

Install the RPM from the automated CI/CD build and then:

Start the yggdrasil service and ensure the new hardcoded default protocol of none is used.

**Test 3:** Confirm /etc/yggdrasil/config.toml is created with all lines commented out

Confirm /etc/yggdrasil/config.toml exists and all lines are commented out.
e.g.:

```
cat /etc/yggdrasil/config.toml
# yggdrasil global configuration settings
#
# protocol = "mqtt"
# server = ["tcp://test.mosquitto.org:1883"]
# log-level = "error"
```

**Test 4:** Confirm /etc/yggdrasil/config.toml is saved to /etc/yggdrasil/config.toml.rpmsave
        when the RPM is uninstalled.

uninstall the yggdrasil RPM and confirm the config.toml file was saved as /etc/yggdrasil/config.toml.rpmsave

```
cat /etc/yggdrasil/config.toml.rpmsave
# yggdrasil global configuration settings
#
# protocol = "mqtt"
# server = ["tcp://test.mosquitto.org:1883"]
# log-level = "error"
```

**Test 5:** Confirm /etc/yggdrasil/config.toml is preserved if it has non-commented out content.

uninstall the yggdrasil RPM

remove all files in directory /etc/yggdrasil/

Create the file /etc/yggdrasil/config.toml with one, uncommented, line.

e.g.:

```
$ cat /etc/yggdrasil/config.toml*
Bob = "Your Uncle"
```

Install the RPM from the automated CI/CD build and then:

Confirm /etc/yggdrasil/config.toml is unchanged and file /etc/yggdrasil/config.toml.rpmnew
was created.

e.g.:

```
$ cat /etc/yggdrasil/config.toml
Bob = "Your Uncle"

$ cat /etc/yggdrasil/config.toml.rpmnew
# yggdrasil global configuration settings
#
# protocol = "mqtt"
# server = ["tcp://test.mosquitto.org:1883"]
# log-level = "error"
```



