### PR TITLE
Include bash-completion in build dependencies

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -12,7 +12,7 @@ jobs:
     container:
       image: registry.fedoraproject.org/fedora:latest
     steps:
-      - run: dnf install --setopt install_weak_deps=False --assumeyes golang git-core meson 'pkgconfig(dbus-1)' 'pkgconfig(systemd)' 'rpm_macro(forgemeta)' jq gh
+      - run: dnf install --setopt install_weak_deps=False --assumeyes golang git-core meson 'pkgconfig(bash-completion)' 'pkgconfig(dbus-1)' 'pkgconfig(systemd)' 'rpm_macro(forgemeta)' jq gh
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.merge_commit_sha }}


### PR DESCRIPTION
Install bash-completion during tag-release workflow