### PR TITLE
Avoid fatal error on ErrProcessDone

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -2,31 +2,18 @@ name: Go
 
 on:
   push:
+    branches: [ "main" ]
   pull_request:
+  workflow_dispatch:
 
 jobs:
   build:
-    name: "Build"
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        go: ['1.19', '1.20']
     steps:
-      - name: Updating ...
-        run: sudo apt-get -qq update
-
-      - uses: actions/checkout@v2
-
-      - name: Setup go
-        uses: actions/setup-go@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
-          go-version: ${{ matrix.go }}
-
-      - name: Go build (source)
-        run: make
-
-      - name: Go build (tests)
-        run: make tests
-
-      - name: Go vet
-        run: make vet
+          go-version: "stable"
+      - run: go build -v ./...
+      - run: go test -v ./...
+      - run: go vet -v ./...

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,31 +1,34 @@
 name: Lint
 
-on: pull_request
+on:
+  pull_request:
+  workflow_dispatch:
 
 jobs:
   lint-commits:
-    name: Lint commits
     runs-on: ubuntu-latest
     steps:
-      - name: Check out code
-        uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.sha }}
-      - uses: actions/cache@v2
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
-      - run: go mod download
-      - name: Run commitsar
-        uses: aevea/commitsar@v0.16.0
+      - uses: aevea/commitsar@v0.20.2
   lint-code:
-    name: Lint code
     runs-on: ubuntu-latest
     steps:
-      - name: Check out code
-        uses: actions/checkout@v2
-      - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v2.5.1
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "stable"
+      - uses: actions/checkout@v4
+      - uses: golangci/golangci-lint-action@v6.5.0
+        with:
+          version: latest
+          args: --verbose --timeout=3m
+      - run: go install github.com/segmentio/golines@latest
+      - run: if [ "$(golines . --dry-run | wc -l)" -gt 0 ]; then exit 1; fi
+  lint-language:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: get-woke/woke-action@v0
+        with:
+          fail-on-error: true

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,6 +1,6 @@
 upstream_package_name: yggdrasil
-downstream_package_name: yggdrasil
-specfile_path: yggdrasil.spec
+downstream_package_name: rhc
+specfile_path: rhc.spec
 
 srpm_build_deps:
   - bash-completion
@@ -12,12 +12,18 @@ srpm_build_deps:
 
 actions:
   post-upstream-clone:
-    - make yggdrasil.spec
-    - make dist
+    - curl -O https://raw.githubusercontent.com/RedHatInsights/rhc/refs/heads/release-0.2/rhc.spec.in
+    - bash -c "make LONGNAME=rhc BRANDNAME=rhc SHORTNAME=rhc PKGNAME=rhc rhc.spec"
   get-current-version:
-    - awk '/^Version:/ {print $2;}' yggdrasil.spec
+    - awk '/^VERSION/ {print $3;}' Makefile
   create-archive:
-    - bash -c 'echo yggdrasil-*.tar.*'
+    - curl -LO https://github.com/RedHatInsights/rhc/releases/download/0.2.6/rhc-0.2.6.tar.gz
+    - curl -LO https://github.com/RedHatInsights/yggdrasil-worker-package-manager/releases/download/0.1.0/yggdrasil-worker-package-manager-0.1.0.tar.gz
+    - make dist
+    - bash -c "echo yggdrasil-${PACKIT_PROJECT_VERSION}.tar.gz"
+  fix-spec-file:
+    - bash -c "sed -i -r \"s/Source1:.*/Source1:\ yggdrasil-${PACKIT_PROJECT_VERSION}.tar.gz/\" rhc.spec"
+    - bash -c "sed -i -r \"s#cd %\{_builddir\}/%\{name\}/yggdrasil-0.2.2#cd %\{_builddir\}/%\{name\}/yggdrasil-${PACKIT_PROJECT_VERSION}#g\" rhc.spec"
 
 jobs:
   - job: copr_build

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,8 @@ TOPICPREFIX := yggdrasil
 DATAHOST := 
 # Used to identify the agency providing the connection broker.
 PROVIDER :=
+# Release value used in spec file
+RELEASE = $(shell printf "0.%s.git.%s" $(shell git rev-list $(shell git describe --tags --abbrev=0 --always | tr -d '\n')..HEAD --count | tr -d '\n') $(shell git rev-parse --short HEAD | tr -d '\n'))
 
 # Installation directories
 PREFIX        ?= /usr/local
@@ -110,7 +112,8 @@ data: $(DATA)
 		-e 's,[@]LONGNAME[@],$(LONGNAME),g' \
 		-e 's,[@]BRANDNAME[@],$(BRANDNAME),g' \
 		-e 's,[@]VERSION[@],$(VERSION),g' \
-		-e 's,[@]PACKAGE[@],$(PACKAGE),g' \
+		-e 's,[@]RELEASE[@],$(RELEASE),g' \
+		-e 's,[@]PKGNAME[@],$(PKGNAME),g' \
 		-e 's,[@]TOPICPREFIX[@],$(TOPICPREFIX),g' \
 		-e 's,[@]DATAHOST[@],$(DATAHOST),g' \
 		-e 's,[@]PROVIDER[@],$(PROVIDER),g' \

--- a/cmd/yggd/exec.go
+++ b/cmd/yggd/exec.go
@@ -81,7 +81,11 @@ func stopProcess(pid int) error {
 	}
 
 	if err := process.Kill(); err != nil {
-		return fmt.Errorf("cannot stop process %v", err)
+		if err != os.ErrProcessDone {
+			return fmt.Errorf("cannot stop process: %v", err)
+		} else {
+			log.Debugf("cannot stop process: process already stopped: %v", err)
+		}
 	}
 
 	return nil


### PR DESCRIPTION
When stopping a process, there is a chance the OS has already stopped the process. In that case, `Process.Kill` returns `os.ErrProcessDone`. This should not be considered a fatal error. This PR handles that case and does not return an error from `stopProcess` if the underlying `Process.Kill` call returns `os.ErrProcessDone`.

There are steps to reproduce this issue in #96, as well as [CCT-1066](https://issues.redhat.com/browse/CCT-1066).

I reproduced it by following steps 1 through 5 in CCT-1066, and then augmenting the running version of rhcd with one from the repository. There are steps in a comment in CCT-1066 that describe this process.

```
sudo go run -ldflags '-X github.com/redhatinsights/yggdrasil.PrefixDir=/usr -X github.com/redhatinsights/yggdrasil.LocalstateDir=/var -X github.com/redhatinsights/yggdrasil.ShortName=rhc -X github.com/redhatinsights/yggdrasil.LongName=rhc' ./cmd/yggd --config /etc/rhc/config.toml --log-level trace --topic-prefix redhat/insights
```

Press Ctrl-C to quit yggd. A message should appear in the console:

```
^Ccannot stop workers: cannot stop worker: cannot stop worker: cannot stop process os: process already finished
```

A PID file should exist at the location `/var/run/rhc/workers/rhc-worker-playbook.worker.pid`. It is the presence of this file, despite the process already being killed, that causes the next invocation of yggd from succeeding. Run the same command above again:
```
sudo go run -ldflags '-X github.com/redhatinsights/yggdrasil.PrefixDir=/usr -X github.com/redhatinsights/yggdrasil.LocalstateDir=/var -X github.com/redhatinsights/yggdrasil.ShortName=rhc -X github.com/redhatinsights/yggdrasil.LongName=rhc' ./cmd/yggd --config /etc/rhc/config.toml --log-level trace --topic-prefix redhat/insights
```

This time, it errors immediately:
```
[rhcd] 2025/02/05 14:23:54 /Users/link/Projects/yggdrasil/cmd/yggd/main.go:197: starting rhcd version
[rhcd] 2025/02/05 14:23:54 /Users/link/Projects/yggdrasil/cmd/yggd/main.go:199: attempting to kill any orphaned workers
cannot stop workers: cannot stop worker: cannot stop worker: cannot stop process os: process already finished
exit status 1
```

Checkout this branch and repeat the steps above. The second time `yggd` is run, the process should proceed instead of exiting with an error.

---
Card ID: [CCT-1066](https://issues.redhat.com/browse/CCT-1066)