### PR TITLE
fix: Do not print scary messages to log for old directive

### DIFF
--- a/internal/work/dbus.go
+++ b/internal/work/dbus.go
@@ -22,9 +22,8 @@ func NewDBusError(name string, body ...string) *dbus.Error {
 func ScrubName(name string) (string, error) {
 	r := regexp.MustCompile("-")
 	if r.Match([]byte(name)) {
-		return string(
-			r.ReplaceAll([]byte(name), []byte("_")),
-		), fmt.Errorf("invalid worker name: %v", name)
+		newName := string(r.ReplaceAll([]byte(name), []byte("_")))
+		return newName, fmt.Errorf("directive name '%v' transformed to '%v'", name, newName)
 	}
 	return name, nil
 }


### PR DESCRIPTION
* When MQTT message with old directive standard is received, then do not print scary message, but only print informative message that name was transformed
* Added one more unit test