### PR TITLE
Enable compile-time default facts file

### DIFF
--- a/cmd/yggd/main.go
+++ b/cmd/yggd/main.go
@@ -551,6 +551,7 @@ func main() {
 			Name:      config.FlagNameFactsFile,
 			Usage:     "Read facts from `FILE`",
 			TakesFile: true,
+			Value:     constants.DefaultFactsFile,
 		}),
 		altsrc.NewIntFlag(&cli.IntFlag{
 			Name:   config.FlagNameHTTPRetries,

--- a/dist/srpm/yggdrasil.spec.in
+++ b/dist/srpm/yggdrasil.spec.in
@@ -39,9 +39,9 @@ Version:        @VERSION@
 %endif
 
 %if 0%{?fedora}
-%global setup_flags -Dvendor=False -Dexamples=True
+%global setup_flags -Dvendor=False -Dexamples=True -Ddefault_facts_file=%{_localstatedir}/lib/yggdrasil/canonical-facts.json
 %else
-%global setup_flags -Dvendor=True -Dexamples=True
+%global setup_flags -Dvendor=True -Dexamples=True -Ddefault_facts_file=%{_localstatedir}/lib/yggdrasil/canonical-facts.json
 %endif
 
 %global common_description %{expand:

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -18,6 +18,9 @@ var (
 	// DefaultDataHost is the default value used to force sending all HTTP
 	// traffic to a specific host.
 	DefaultDataHost string
+
+	// DefaultFactsFile is the default value used to read facts about the host.
+	DefaultFactsFile string
 )
 
 // Installation directory prefix and paths. Values have hard-coded defaults but

--- a/meson.build
+++ b/meson.build
@@ -13,6 +13,7 @@ endif
 goldflags = get_option('goldflags')
 goldflags += ' -X "github.com/redhatinsights/yggdrasil/internal/constants.Version=' + meson.project_version() + '"'
 goldflags += ' -X "github.com/redhatinsights/yggdrasil/internal/constants.DefaultPathPrefix=' + get_option('default_path_prefix') + '"'
+goldflags += ' -X "github.com/redhatinsights/yggdrasil/internal/constants.DefaultFactsFile=' + get_option('default_facts_file') + '"'
 goldflags += ' -X "github.com/redhatinsights/yggdrasil/internal/constants.PrefixDir=' + get_option('prefix') + '"'
 goldflags += ' -X "github.com/redhatinsights/yggdrasil/internal/constants.SysconfDir=' + get_option('sysconfdir') + '"'
 goldflags += ' -X "github.com/redhatinsights/yggdrasil/internal/constants.LocalstateDir=' + get_option('localstatedir') + '"'
@@ -56,6 +57,7 @@ summary(
   {
     'default_data_host': get_option('default_data_host'),
     'default_path_prefix': get_option('default_path_prefix'),
+    'default_facts_file': get_option('default_facts_file'),
     'vendor': get_option('vendor'),
     'examples': get_option('examples'),
     'user': get_option('user'),

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,5 +1,6 @@
 option('default_data_host', type: 'string', description: 'Set the compile-time value for the default download hostname')
 option('default_path_prefix', type: 'string', value: 'yggdrasil', description: 'Set the compile-time value for the default path prefix')
+option('default_facts_file', type: 'string', value: '', description: 'Set the compile-time value for the default facts file path')
 option('vendor', type: 'boolean', value: false, description: 'Bundle go module dependencies in the vendor directory')
 option('examples', type: 'boolean', value: false, description: 'Build and install the example workers')
 option('gobuildflags', type: 'array', value: ['-buildmode', 'pie'], description: 'Additional build flags to be passed to the Go compiler')


### PR DESCRIPTION
By way of a new build option, default_facts_file, enable a compile-time default value for the facts-file flag. The RPMs built out of `dist/srpm` are updated to build with this value set to /var/lib/yggdrasil/canonical-facts.json.

To verify this behavior, make sure that the line defining `facts-file` is removed or commented out from your config file (`/etc/yggdrasil/config.toml`). Running `yggdrasil.service` from this branch on a fully registered system should still find the file `/var/lib/yggdrasil/canonical-facts.json`.

If you connect your yggdrasil to a local broker, you can subscribe to its topics and confirm that facts are still published in the "connection-status" message. Otherwise, connecting your yggdrasil to connect.cloud.stage.redhat.com means you'll have to either scour Kibana logs for your messages being received by cloud-connector or assume that facts got there.

The local yggdrasil logs should not report any errors about a missing facts file.

Card ID: [CCT-1164](https://issues.redhat.com/browse/CCT-1164)