### PR TITLE
ci: fix packit config for post-merge builds

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -45,7 +45,7 @@ jobs:
     identifier: "build/el9"
     additional_repos:
       - "copr://@yggdrasil/el9"
-    branch: main
+    branch: "yggdrasil-0.2"
     owner: "@yggdrasil"
     project: el9
     targets:
@@ -59,7 +59,7 @@ jobs:
     identifier: "build/el8"
     additional_repos:
       - "copr://@yggdrasil/el8"
-    branch: main
+    branch: "yggdrasil-0.2"
     owner: "@yggdrasil"
     project: el8
     targets:


### PR DESCRIPTION
Specify the right branch of this branch, so packit triggers the build correctly.

Fixes commit aa62e381658d72051fec00382fa39288b0c2045a.