### PR TITLE
fix: Create rhcd.service sym link to yggdrasil.service

### DIFF
--- a/dist/srpm/yggdrasil.spec.in
+++ b/dist/srpm/yggdrasil.spec.in
@@ -125,6 +125,7 @@ install -d -m 0755 %{buildroot}%{_sysconfdir}/yggdrasil
 %sysusers_create_compat %{SOURCE1}
 
 %post
+ln -s %{_unitdir}/yggdrasil.service %{_unitdir}/rhcd.service
 %systemd_post %{name}.service
 %systemd_user_post %{name}.service
 
@@ -133,6 +134,7 @@ install -d -m 0755 %{buildroot}%{_sysconfdir}/yggdrasil
 %systemd_user_preun %{name}.service
 
 %postun
+rm -f %{_unitdir}/rhcd.service
 %systemd_postun_with_restart %{name}.service
 %systemd_user_postun_with_restart %{name}.service
 


### PR DESCRIPTION
Card ID: CCT-1228

This changes will create the symlink  /usr/lib/systemd/system/rhcd.service pointing to  /usr/lib/systemd/system/yggdrasil.service

To test this, after the COPR rpm is installed the following ls command should show the sym link
For example:

```
$ ls -aFl /usr/lib/systemd/system/rhcd.service
lrwxrwxrwx. 1 root root 41 Mar 10 14:10 /usr/lib/systemd/system/rhcd.service -> /usr/lib/systemd/system/yggdrasil.service

```