### PR TITLE
ci: Enable network for Packit build

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -28,6 +28,7 @@ actions:
 jobs:
   - job: copr_build
     trigger: pull_request
+    enable_net: True
     additional_repos:
       - "copr://@yggdrasil/latest"
     targets:
@@ -42,6 +43,7 @@ jobs:
 
   - job: copr_build
     trigger: commit
+    enable_net: True
     branch: main
     owner: "@yggdrasil"
     project: latest


### PR DESCRIPTION
* Try to fix issue with downloading required go modules during build process. The network is disabled by default.
* Documentation for new option: https://packit.dev/docs/configuration/upstream/copr_build#optional-parameters