### PR TITLE
fix: Stop using git.sr.ht/~spc/go-log and use copy on github.com

### DIFF
--- a/cmd/yggctl/main.go
+++ b/cmd/yggctl/main.go
@@ -6,7 +6,7 @@ import (
 	"regexp"
 	"strings"
 
-	"git.sr.ht/~spc/go-log"
+	"github.com/subpop/go-log"
 
 	"github.com/redhatinsights/yggdrasil/internal/constants"
 	"github.com/urfave/cli/v2"

--- a/cmd/yggd/client.go
+++ b/cmd/yggd/client.go
@@ -10,7 +10,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"git.sr.ht/~spc/go-log"
 	"github.com/godbus/dbus/v5"
 	"github.com/godbus/dbus/v5/introspect"
 	"github.com/google/uuid"
@@ -23,6 +22,7 @@ import (
 	"github.com/redhatinsights/yggdrasil/internal/transport"
 	"github.com/redhatinsights/yggdrasil/internal/work"
 	"github.com/redhatinsights/yggdrasil/ipc"
+	"github.com/subpop/go-log"
 )
 
 // Client is a high-level data structure that owns a dispatcher and a

--- a/cmd/yggd/flag.go
+++ b/cmd/yggd/flag.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io"
 
-	"git.sr.ht/~spc/go-log"
+	"github.com/subpop/go-log"
 	"github.com/urfave/cli/v2"
 )
 

--- a/cmd/yggd/main.go
+++ b/cmd/yggd/main.go
@@ -18,9 +18,9 @@ import (
 	"github.com/redhatinsights/yggdrasil/internal/transport"
 	"github.com/redhatinsights/yggdrasil/internal/work"
 
-	"git.sr.ht/~spc/go-log"
 	"github.com/redhatinsights/yggdrasil"
 	"github.com/rjeczalik/notify"
+	"github.com/subpop/go-log"
 	"github.com/urfave/cli/v2"
 	"github.com/urfave/cli/v2/altsrc"
 )

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.22.0
 toolchain go1.23.6
 
 require (
-	git.sr.ht/~spc/go-log v0.1.1
+	github.com/subpop/go-log v0.1.2
 	github.com/adrg/xdg v0.5.3
 	github.com/coreos/go-systemd/v22 v22.5.0
 	github.com/eclipse/paho.mqtt.golang v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-git.sr.ht/~spc/go-log v0.1.1 h1:pdfV6Q1pNcGVT77DAWzc6LxJyi83PRu1ioZo98ZobAU=
-git.sr.ht/~spc/go-log v0.1.1/go.mod h1:Albq15b/jXGrQ659oyB8X1wX8quqpU+LxXFw7YmEuTg=
 github.com/BurntSushi/toml v1.4.0 h1:kuoIxZQy2WRRk1pttg9asf+WVv6tWQuBNVmK8+nqPr0=
 github.com/BurntSushi/toml v1.4.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/adrg/xdg v0.5.3 h1:xRnxJXne7+oWDatRhR1JLnvuccuIeCoBu2rtuLqQB78=
@@ -45,6 +43,10 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/subpop/go-log v0.1.1 h1:SVWMwHX4QRSsHNl0cRNoytL5uPVFoQhv4pdTa5PnBt4=
+github.com/subpop/go-log v0.1.1/go.mod h1:Albq15b/jXGrQ659oyB8X1wX8quqpU+LxXFw7YmEuTg=
+github.com/subpop/go-log v0.1.2 h1:NgbZR6frmeDtC+96d+UxOkt4X/JxO626fokwL56Dff0=
+github.com/subpop/go-log v0.1.2/go.mod h1:uAEovif98swmWm/8qYGrzGFahUIRQ/KwlBUpJuoOdds=
 github.com/urfave/cli/v2 v2.27.6 h1:VdRdS98FNhKZ8/Az8B7MTyGQmpIr36O1EHybx/LaZ4g=
 github.com/urfave/cli/v2 v2.27.6/go.mod h1:3Sevf16NykTbInEnD0yKkjDAeZDS0A6bzhBH5hrMvTQ=
 github.com/xrash/smetrics v0.0.0-20240521201337-686a1a2994c1 h1:gEOO8jv9F4OT7lGCjxCBTO/36wtF6j2nSip77qHd4x4=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -6,9 +6,9 @@ import (
 	"os"
 	"time"
 
-	"git.sr.ht/~spc/go-log"
 	"github.com/redhatinsights/yggdrasil/internal/constants"
 	"github.com/rjeczalik/notify"
+	"github.com/subpop/go-log"
 )
 
 const (

--- a/internal/http/client.go
+++ b/internal/http/client.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"time"
 
-	"git.sr.ht/~spc/go-log"
+	"github.com/subpop/go-log"
 )
 
 // Client is a specialized HTTP client, configured with mutual TLS certificate

--- a/internal/messagejournal/messagejournal.go
+++ b/internal/messagejournal/messagejournal.go
@@ -10,13 +10,13 @@ import (
 	"text/template"
 	"time"
 
-	"git.sr.ht/~spc/go-log"
 	"github.com/golang-migrate/migrate/v4"
 	"github.com/golang-migrate/migrate/v4/database/sqlite3"
 	"github.com/golang-migrate/migrate/v4/source/iofs"
 	_ "github.com/mattn/go-sqlite3"
 	"github.com/redhatinsights/yggdrasil"
 	"github.com/redhatinsights/yggdrasil/ipc"
+	"github.com/subpop/go-log"
 )
 
 //go:embed migrations/*.sql

--- a/internal/tags/tags.go
+++ b/internal/tags/tags.go
@@ -8,8 +8,8 @@ import (
 	"strconv"
 	"time"
 
-	"git.sr.ht/~spc/go-log"
 	"github.com/pelletier/go-toml"
+	"github.com/subpop/go-log"
 )
 
 type errorTag struct {

--- a/internal/transport/http.go
+++ b/internal/transport/http.go
@@ -11,9 +11,9 @@ import (
 	"sync/atomic"
 	"time"
 
-	"git.sr.ht/~spc/go-log"
 	"github.com/redhatinsights/yggdrasil/internal/config"
 	internalhttp "github.com/redhatinsights/yggdrasil/internal/http"
+	"github.com/subpop/go-log"
 )
 
 // HTTPResponse is a data structure representing an HTTP response received from

--- a/internal/transport/mqtt.go
+++ b/internal/transport/mqtt.go
@@ -7,12 +7,12 @@ import (
 	"os"
 	"time"
 
-	"git.sr.ht/~spc/go-log"
 	mqtt "github.com/eclipse/paho.mqtt.golang"
 	"github.com/google/uuid"
 	"github.com/redhatinsights/yggdrasil"
 	"github.com/redhatinsights/yggdrasil/internal/config"
 	"github.com/redhatinsights/yggdrasil/internal/constants"
+	"github.com/subpop/go-log"
 )
 
 // MQTT is a Transporter that sends and receives data and control

--- a/internal/work/dispatcher.go
+++ b/internal/work/dispatcher.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 	"time"
 
-	"git.sr.ht/~spc/go-log"
 	"github.com/godbus/dbus/v5"
 	"github.com/godbus/dbus/v5/introspect"
 	"github.com/redhatinsights/yggdrasil"
@@ -19,6 +18,7 @@ import (
 	"github.com/redhatinsights/yggdrasil/internal/messagejournal"
 	"github.com/redhatinsights/yggdrasil/internal/sync"
 	"github.com/redhatinsights/yggdrasil/ipc"
+	"github.com/subpop/go-log"
 )
 
 const (

--- a/worker/echo/main.go
+++ b/worker/echo/main.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/google/uuid"
 
-	"git.sr.ht/~spc/go-log"
+	"github.com/subpop/go-log"
 
 	"github.com/redhatinsights/yggdrasil/internal/sync"
 	"github.com/redhatinsights/yggdrasil/ipc"

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -6,11 +6,11 @@ import (
 	"path"
 	"regexp"
 
-	"git.sr.ht/~spc/go-log"
 	"github.com/godbus/dbus/v5"
 	"github.com/godbus/dbus/v5/introspect"
 	"github.com/godbus/dbus/v5/prop"
 	"github.com/redhatinsights/yggdrasil/ipc"
+	"github.com/subpop/go-log"
 )
 
 // RxFunc is a function type that gets called each time the worker receives data.


### PR DESCRIPTION
* Trying to get go-log module from [git.sr.ht/~spc/go-log](https://git.sr.ht/~spc/go-log) started to be terminated with 403 error yesterday
* For this reason we decided to use existing Link's copy on GitHub, because this server should be more reliable. Link is the main author of go-log
* TODO: Really change yggdrasil to use log/slog