### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   lint-commits:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/RedHatInsights/yggdrasil/security/code-scanning/3](https://github.com/RedHatInsights/yggdrasil/security/code-scanning/3)

To fix the issue, we will add a `permissions` block at the root level of the workflow. This block will apply to all jobs in the workflow unless overridden by job-specific `permissions`. Since the workflow is for linting, it only requires read access to the repository contents. We will set `contents: read` as the minimal required permission.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
