### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/RedHatInsights/yggdrasil/security/code-scanning/5](https://github.com/RedHatInsights/yggdrasil/security/code-scanning/5)

To fix the issue, we will add a `permissions` block at the root level of the workflow. This block will specify `contents: read`, which is sufficient for the operations performed in this workflow. This change ensures that the workflow adheres to the principle of least privilege by restricting the `GITHUB_TOKEN` to read-only access to repository contents.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
