### PR TITLE
fix: Only root user can call use com.redhat.Yggdrasil1

### DIFF
--- a/data/dbus/yggd.conf.in
+++ b/data/dbus/yggd.conf.in
@@ -15,8 +15,8 @@
     <allow send_destination="com.redhat.Yggdrasil1.Dispatcher1" />
   </policy>
 
-  <policy context="default">
-    <!-- Anyone can send messages to the Yggdrasil1 destination. -->
+  <policy user="root">
+    <!-- Only root can send messages to the Yggdrasil1 destination. -->
     <allow send_destination="com.redhat.Yggdrasil1" />
   </policy>
 </busconfig>


### PR DESCRIPTION
* Card ID: [RHEL-88585](https://issues.redhat.com/browse/RHEL-88585)
* CVE: [CVE-2025-3931](https://access.redhat.com/security/cve/CVE-2025-3931)
  * Local user was able to dispatch content for any yggdrasil worker using D-Bus method Dispatch(). If there was any worker installed and the worker used root user instead some system user, then it could lead to a local privilege escalation
* Only root user should be able to call methods in `com.redhat.Yggdrasil1` destination
* No local user needs to call methods in this destination

## Summary by Sourcery

Bug Fixes:
- Allow only the root user to call methods on the com.redhat.Yggdrasil1 D-Bus interface to address CVE-2025-3931