### PR TITLE
feat: changed default runtime system paths for bootc compatibility (rhel-9)

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -9,13 +9,13 @@ the `install` target. Additional variables can be used to further configure the
 installation prefix and related directories.
 
 ```
-PREFIX        ?= /usr/local
+PREFIX        ?= /
 BINDIR        ?= $(PREFIX)/bin
 SBINDIR       ?= $(PREFIX)/sbin
 LIBEXECDIR    ?= $(PREFIX)/libexec
 SYSCONFDIR    ?= $(PREFIX)/etc
-DATADIR       ?= $(PREFIX)/share
-DATAROOTDIR   ?= $(PREFIX)/share
+DATADIR       ?= $(PREFIX)/usr/share
+DATAROOTDIR   ?= $(PREFIX)/usr/share
 MANDIR        ?= $(DATADIR)/man
 DOCDIR        ?= $(PREFIX)/doc
 LOCALSTATEDIR ?= $(PREFIX)/var

--- a/Makefile
+++ b/Makefile
@@ -28,13 +28,13 @@ PROVIDER :=
 RELEASE = $(shell printf "0.%s.git.%s" $(shell git rev-list $(shell git describe --tags --abbrev=0 --always | tr -d '\n')..HEAD --count | tr -d '\n') $(shell git rev-parse --short HEAD | tr -d '\n'))
 
 # Installation directories
-PREFIX        ?= /usr/local
+PREFIX        ?= /
 BINDIR        ?= $(PREFIX)/bin
 SBINDIR       ?= $(PREFIX)/sbin
 LIBEXECDIR    ?= $(PREFIX)/libexec
 SYSCONFDIR    ?= $(PREFIX)/etc
-DATADIR       ?= $(PREFIX)/share
-DATAROOTDIR   ?= $(PREFIX)/share
+DATADIR       ?= $(PREFIX)/usr/share
+DATAROOTDIR   ?= $(PREFIX)/usr/share
 MANDIR        ?= $(DATADIR)/man
 DOCDIR        ?= $(DATADIR)/doc
 LOCALSTATEDIR ?= $(PREFIX)/var

--- a/constants.go
+++ b/constants.go
@@ -45,7 +45,7 @@ var (
 
 func init() {
 	if PrefixDir == "" {
-		PrefixDir = "/usr/local"
+		PrefixDir = "/"
 	}
 	if BinDir == "" {
 		BinDir = filepath.Join(PrefixDir, "bin")
@@ -57,10 +57,10 @@ func init() {
 		LibexecDir = filepath.Join(PrefixDir, "libexec")
 	}
 	if DataDir == "" {
-		DataDir = filepath.Join(PrefixDir, "share")
+		DataDir = filepath.Join(PrefixDir, "usr", "share")
 	}
 	if DatarootDir == "" {
-		DatarootDir = filepath.Join(PrefixDir, "share")
+		DatarootDir = filepath.Join(PrefixDir, "usr", "share")
 	}
 	if ManDir == "" {
 		ManDir = filepath.Join(PrefixDir, "man")


### PR DESCRIPTION
This patch changes the default installation prefix from '/usr/local' to '/' and use standard filesystem hierarchy paths ('/var', '/etc', '/usr/share') instead of '/usr/local' paths to ensure compatibility with bootc environments where '/usr' is read-only.

Changes:
- PREFIX: /usr/local -> /
- LocalstateDir: /usr/local/var -> /var
- SysconfDir: /usr/local/etc -> /etc
- DataDir: /usr/local/share -> /usr/share