### PR TITLE
test: verify Yggdrasil publishes canonical facts without defined facts-file

### DIFF
--- a/integration-tests/requirements.txt
+++ b/integration-tests/requirements.txt
@@ -1,0 +1,2 @@
+git+https://github.com/RedHatInsights/pytest-client-tools@main
+paho-mqtt

--- a/integration-tests/test_echo_worker.py
+++ b/integration-tests/test_echo_worker.py
@@ -6,14 +6,12 @@ It indirectly tests that yggdrasil service dispatch MQTT message to
 import subprocess
 import logging
 import time
-from utils import loop_until
+from utils import loop_until, get_yggdrasil_client_id
 
 logger = logging.getLogger(__name__)
 
 # The scheme could be "mqtt://" or "mqtts://"
 MQTT_SERVER_URL = "mqtt://localhost:1883"
-
-YGGDRASIL_CLIENT_ID_PATH = "/var/lib/yggdrasil/client-id"
 
 ECHO_WORKER_DIRECTIVE = "echo"
 
@@ -22,20 +20,6 @@ ECHO_WORKER_SERVICE = "com.redhat.Yggdrasil1.Worker1.echo.service"
 mqtt_message = """
 "hello"
 """
-
-def get_yggdrasil_client_id():
-    """
-    Try to get yggdrasil client ID used in MQTT messages
-    :return: client ID string
-    """
-    logger.info("Getting yggdrasil client ID")
-    try:
-        with open(YGGDRASIL_CLIENT_ID_PATH, "r") as client_id_file:
-            client_id = client_id_file.read()
-    except IOError as err:
-        logger.error(f"unable to read '{YGGDRASIL_CLIENT_ID_PATH}': {err}")
-        client_id = None
-    return client_id
 
 def is_echo_worker_running():
     """

--- a/integration-tests/test_yggdrasil_default_facts_file.py
+++ b/integration-tests/test_yggdrasil_default_facts_file.py
@@ -1,0 +1,116 @@
+import subprocess
+import json
+import time
+import pytest
+import paho.mqtt.client as mqtt
+from utils import (
+    yggdrasil_service_is_active,
+    get_yggdrasil_config_details,
+    get_yggdrasil_client_id,
+)
+
+
+def test_yggdrasil_publishes_canonical_facts(external_candlepin, rhc, test_config):
+    """
+    :title: Verify Yggdrasil publishes canonical facts using default facts file.
+    :description:
+        This test verifies that Yggdrasil publishes canonical facts using the default 
+facts file when the facts-file configuration is not defined in the config.toml file.
+    :steps:
+        1.  Comment out any existing facts-file configuration in /etc/yggdrasil/config.toml.
+        2.  Connect the system using 'rhc connect' to ensure facts are available.
+        3.  Verify that RHC reports being registered.
+        4.  Verify that the yggdrasil service is active.
+        5.  Configure MQTT server to localhost and restart yggdrasil service.
+        6.  Verify canonical_facts got published on MQTT topics.
+    :expectedresults:
+        1.  The facts-file configuration is successfully commented out.
+        2.  The 'rhc connect' command executes successfully.
+        3.  RHC indicates the system is registered.
+        4.  The yggdrasil service is in an active state.
+        5.  MQTT configuration is updated and yggdrasil service restarts successfully.
+        6.  Canonical facts are published and received on the expected MQTT topic.
+    """
+
+    try:
+        # Ensure facts-file is not defined in config (comment it out if it exists)
+        subprocess.run(
+            ["sed", "-i", r"s/^facts-file/#facts-file/", "/etc/yggdrasil/config.toml"],
+            check=False,
+        )
+
+        # run rhc connect so that some facts are available for testing
+        rhc.connect(
+            username=test_config.get("candlepin.username"),
+            password=test_config.get("candlepin.password"),
+        )
+        # validate the connection
+        assert rhc.is_registered
+        assert yggdrasil_service_is_active()
+
+        # Verify canonical_facts were published to MQTT
+        assert wait_for_canonical_facts(), "No canonical_facts published on MQTT topics"
+
+    finally:
+        # restore the original facts-file configuration in config.toml
+        subprocess.run(
+            ["sed", "-i", r"s/^#facts-file/facts-file/", "/etc/yggdrasil/config.toml"],
+            check=False,
+        )
+
+
+def wait_for_canonical_facts(timeout: int = 30) -> dict:
+    """
+    Wait for canonical_facts in a connection-status message from yggdrasil MQTT broker.
+
+    Args:
+        timeout (int): seconds to wait before giving up.
+
+    Returns:
+        dict: canonical_facts if found, else None
+    """
+    canonical_facts = {}
+
+    def on_message(client, userdata, msg):
+        nonlocal canonical_facts
+        try:
+            payload = json.loads(msg.payload.decode())
+            if payload.get("type") == "connection-status":
+                facts = payload.get("content", {}).get("canonical_facts")
+                if facts:
+                    canonical_facts = facts
+                    client.disconnect()
+        except Exception as e:
+            print(f"Error parsing message: {e}")
+
+    # set mqtt server url to localhost for yggdrasil service so that we can subscribe to topic and
+    # receive facts locally
+    subprocess.run(
+        [
+            "sed",
+            "-i",
+            r"/^#\?server\s*=/d; 1a server = [\"mqtt://localhost:1883\"]",
+            "/etc/yggdrasil/config.toml",
+        ],
+        check=False,
+    )
+    host, port, path_prefix = get_yggdrasil_config_details()
+    client_id = get_yggdrasil_client_id()
+    if not client_id:
+        raise RuntimeError("Unable to determine yggdrasil client ID")
+
+    topic = f"{path_prefix}/{client_id}/control/out"
+
+    client = mqtt.Client()
+    client.on_message = on_message
+    client.connect(host, port, 60)
+    client.subscribe(topic)
+
+    # Restart yggdrasil service to pick up new configuration and publish fresh facts
+    subprocess.run(["systemctl", "restart", "yggdrasil"], check=False)
+
+    start = time.time()
+    while not canonical_facts and (time.time() - start) < timeout:
+        client.loop(timeout=1.0)
+
+    return canonical_facts if canonical_facts else None

--- a/integration-tests/utils.py
+++ b/integration-tests/utils.py
@@ -2,7 +2,31 @@
 This module contains utilities for yggdrasil integration tests.
 """
 
+import subprocess
 import time
+import logging
+import os
+import tomllib
+
+logger = logging.getLogger(__name__)
+
+# Path to yggdrasil client ID file
+YGGDRASIL_CLIENT_ID_PATH = "/var/lib/yggdrasil/client-id"
+
+
+def get_yggdrasil_client_id():
+    """
+    Try to get yggdrasil client ID used in MQTT messages
+    :return: client ID string
+    """
+    logger.info("Getting yggdrasil client ID")
+    try:
+        with open(YGGDRASIL_CLIENT_ID_PATH, "r") as client_id_file:
+            client_id = client_id_file.read()
+    except IOError as err:
+        logger.error(f"unable to read '{YGGDRASIL_CLIENT_ID_PATH}': {err}")
+        client_id = None
+    return client_id
 
 def loop_until(function, assertation, poll_sec=1, timeout_sec=10):
     """
@@ -24,3 +48,50 @@ def loop_until(function, assertation, poll_sec=1, timeout_sec=10):
         function_result = function()
         result = assertation(function_result)
     return result
+
+
+
+def get_yggdrasil_config_details(config_path="/etc/yggdrasil/config.toml"):
+    """
+    Get server host, port, path-prefix from yggdrasil config.toml.
+
+    Returns:
+        tuple: (server_host, server_port, path_prefix)
+    """
+    if not os.path.exists(config_path):
+        raise FileNotFoundError(f"Config file not found: {config_path}")
+
+    with open(config_path, "rb") as f:
+        config = tomllib.load(f)
+
+    servers = config.get("server", [])
+    if not servers:
+        raise ValueError("No 'server' entry found in config.toml")
+
+    # Parse the first server entry (e.g., tcp://localhost:1883, mqtt://example.com:8883, etc.)
+    server_url = servers[0]
+    
+    # Remove protocol prefix if present
+    if "://" in server_url:
+        protocol, server_url = server_url.split("://", 1)
+    
+    # Split host and port
+    if ":" in server_url:
+        host, port = server_url.rsplit(":", 1)  # rsplit to handle IPv6 addresses
+    else:
+        raise ValueError(f"No port specified in server URL: {servers[0]}")
+    path_prefix = config.get("path-prefix", "yggdrasil")
+    return host, int(port), path_prefix
+
+def yggdrasil_service_is_active():
+    """
+    Check if yggdrasil service is active/running
+    :return: Return True when yggdrasil service is active
+    """
+    proc = subprocess.run(
+        ["systemctl", "is-active", "yggdrasil"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        universal_newlines=True,
+    )
+    return proc.returncode == 0 and proc.stdout.strip() == "active"


### PR DESCRIPTION
This integration test verifies that Yggdrasil publishes facts using default facts file when facts-file is not defined in config.
Also moved  'get_yggdrasil_client_id()' to utils.py so that other tests can use it.
