### PR TITLE
fix: set HTTP client timeout and max idle connection timeout

### DIFF
--- a/cmd/yggd/main.go
+++ b/cmd/yggd/main.go
@@ -53,25 +53,27 @@ func generateDocumentation(c *cli.Context) error {
 // CLI flags and arguments.
 func setupDefaultConfig(c *cli.Context) {
 	config.DefaultConfig = config.Config{
-		LogLevel:                 c.String(config.FlagNameLogLevel),
-		ClientID:                 c.String(config.FlagNameClientID),
-		Server:                   c.StringSlice(config.FlagNameServer),
-		CertFile:                 c.String(config.FlagNameCertFile),
-		KeyFile:                  c.String(config.FlagNameKeyFile),
-		CARoot:                   c.StringSlice(config.FlagNameCaRoot),
-		PathPrefix:               c.String(config.FlagNamePathPrefix),
-		Protocol:                 c.String(config.FlagNameProtocol),
-		DataHost:                 c.String(config.FlagNameDataHost),
-		FactsFile:                c.String(config.FlagNameFactsFile),
-		HTTPRetries:              c.Int(config.FlagNameHTTPRetries),
-		HTTPTimeout:              c.Duration(config.FlagNameHTTPTimeout),
-		MQTTConnectRetry:         c.Bool(config.FlagNameMQTTConnectRetry),
-		MQTTConnectRetryInterval: c.Duration(config.FlagNameMQTTConnectRetryInterval),
-		MQTTAutoReconnect:        c.Bool(config.FlagNameMQTTAutoReconnect),
-		MQTTReconnectDelay:       c.Duration(config.FlagNameMQTTReconnectDelay),
-		MQTTConnectTimeout:       c.Duration(config.FlagNameMQTTConnectTimeout),
-		MQTTPublishTimeout:       c.Duration(config.FlagNameMQTTPublishTimeout),
-		MessageJournal:           c.String(config.FlagNameMessageJournal),
+		LogLevel:                  c.String(config.FlagNameLogLevel),
+		ClientID:                  c.String(config.FlagNameClientID),
+		Server:                    c.StringSlice(config.FlagNameServer),
+		CertFile:                  c.String(config.FlagNameCertFile),
+		KeyFile:                   c.String(config.FlagNameKeyFile),
+		CARoot:                    c.StringSlice(config.FlagNameCaRoot),
+		PathPrefix:                c.String(config.FlagNamePathPrefix),
+		Protocol:                  c.String(config.FlagNameProtocol),
+		DataHost:                  c.String(config.FlagNameDataHost),
+		FactsFile:                 c.String(config.FlagNameFactsFile),
+		HTTPRetries:               c.Int(config.FlagNameHTTPRetries),
+		HTTPTimeout:               c.Duration(config.FlagNameHTTPTimeout),
+		HTTPIdleConnTimeout:       c.Duration(config.FlagNameHTTPIdleConnTimeout),
+		HTTPResponseHeaderTimeout: c.Duration(config.FlagNameHTTPResponseHeaderTimeout),
+		MQTTConnectRetry:          c.Bool(config.FlagNameMQTTConnectRetry),
+		MQTTConnectRetryInterval:  c.Duration(config.FlagNameMQTTConnectRetryInterval),
+		MQTTAutoReconnect:         c.Bool(config.FlagNameMQTTAutoReconnect),
+		MQTTReconnectDelay:        c.Duration(config.FlagNameMQTTReconnectDelay),
+		MQTTConnectTimeout:        c.Duration(config.FlagNameMQTTConnectTimeout),
+		MQTTPublishTimeout:        c.Duration(config.FlagNameMQTTPublishTimeout),
+		MessageJournal:            c.String(config.FlagNameMessageJournal),
 	}
 }
 
@@ -175,6 +177,7 @@ func setupClient(
 			tlsConfig,
 			UserAgent,
 			time.Second*5,
+			config.DefaultConfig.HTTPResponseHeaderTimeout,
 		)
 		if err != nil {
 			return nil, nil, cli.Exit(fmt.Errorf("cannot create HTTP transport: %w", err), 1)
@@ -227,6 +230,17 @@ func setupMessageJournal(client *Client) error {
 	return nil
 }
 
+// configuredHTTPClient creates an HTTP client with all config-driven settings
+// applied (retries, timeouts).
+func configuredHTTPClient(tlsConfig *tls.Config) *http.Client {
+	client := http.NewHTTPClient(tlsConfig, UserAgent)
+	client.Retries = config.DefaultConfig.HTTPRetries
+	client.Timeout = config.DefaultConfig.HTTPTimeout
+	client.SetIdleConnTimeout(config.DefaultConfig.HTTPIdleConnTimeout)
+	client.SetResponseHeaderTimeout(config.DefaultConfig.HTTPResponseHeaderTimeout)
+	return client
+}
+
 // setupTLS tries to set up new TLS config and HTTP client
 func setupTLS() (*http.Client, *tls.Config, error) {
 	tlsConfig, err := config.DefaultConfig.CreateTLSConfig()
@@ -234,11 +248,7 @@ func setupTLS() (*http.Client, *tls.Config, error) {
 		return nil, nil, cli.Exit(fmt.Errorf("cannot create TLS config: %w", err), 1)
 	}
 
-	httpClient := http.NewHTTPClient(tlsConfig, UserAgent)
-	httpClient.Retries = config.DefaultConfig.HTTPRetries
-	httpClient.Timeout = config.DefaultConfig.HTTPTimeout
-
-	return httpClient, tlsConfig, nil
+	return configuredHTTPClient(tlsConfig), tlsConfig, nil
 }
 
 // publishConnectionStatus tries to publish connection status to server
@@ -331,8 +341,7 @@ func monitorCertificate(
 		log.Info("transport TLS configuration reloaded")
 
 		log.Debug("setting dispatcher HTTP client")
-		httpClient := http.NewHTTPClient(cfg, UserAgent)
-		dispatcher.HTTPClient = httpClient
+		dispatcher.HTTPClient = configuredHTTPClient(cfg)
 		log.Info("dispatcher HTTP client updated")
 	}
 }
@@ -599,6 +608,19 @@ func main() {
 		altsrc.NewDurationFlag(&cli.DurationFlag{
 			Name:   config.FlagNameHTTPTimeout,
 			Usage:  "Wait for `DURATION` before cancelling an HTTP request",
+			Value:  30 * time.Second,
+			Hidden: true,
+		}),
+		altsrc.NewDurationFlag(&cli.DurationFlag{
+			Name:   config.FlagNameHTTPIdleConnTimeout,
+			Usage:  "Close idle HTTP connections after `DURATION`",
+			Value:  30 * time.Second,
+			Hidden: true,
+		}),
+		altsrc.NewDurationFlag(&cli.DurationFlag{
+			Name:   config.FlagNameHTTPResponseHeaderTimeout,
+			Usage:  "Wait for `DURATION` for response headers before cancelling an HTTP request",
+			Value:  30 * time.Second,
 			Hidden: true,
 		}),
 		altsrc.NewBoolFlag(&cli.BoolFlag{

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -12,25 +12,27 @@ import (
 )
 
 const (
-	FlagNameLogLevel                 = "log-level"
-	FlagNameCertFile                 = "cert-file"
-	FlagNameKeyFile                  = "key-file"
-	FlagNameCaRoot                   = "ca-root"
-	FlagNameServer                   = "server"
-	FlagNameClientID                 = "client-id"
-	FlagNamePathPrefix               = "path-prefix"
-	FlagNameProtocol                 = "protocol"
-	FlagNameDataHost                 = "data-host"
-	FlagNameFactsFile                = "facts-file"
-	FlagNameHTTPRetries              = "http-retries"
-	FlagNameHTTPTimeout              = "http-timeout"
-	FlagNameMQTTConnectRetry         = "mqtt-connect-retry"
-	FlagNameMQTTConnectRetryInterval = "mqtt-connect-retry-interval"
-	FlagNameMQTTAutoReconnect        = "mqtt-auto-reconnect"
-	FlagNameMQTTReconnectDelay       = "mqtt-reconnect-delay"
-	FlagNameMQTTConnectTimeout       = "mqtt-connect-timeout"
-	FlagNameMQTTPublishTimeout       = "mqtt-publish-timeout"
-	FlagNameMessageJournal           = "message-journal"
+	FlagNameLogLevel                  = "log-level"
+	FlagNameCertFile                  = "cert-file"
+	FlagNameKeyFile                   = "key-file"
+	FlagNameCaRoot                    = "ca-root"
+	FlagNameServer                    = "server"
+	FlagNameClientID                  = "client-id"
+	FlagNamePathPrefix                = "path-prefix"
+	FlagNameProtocol                  = "protocol"
+	FlagNameDataHost                  = "data-host"
+	FlagNameFactsFile                 = "facts-file"
+	FlagNameHTTPRetries               = "http-retries"
+	FlagNameHTTPTimeout               = "http-timeout"
+	FlagNameHTTPIdleConnTimeout       = "http-idle-conn-timeout"
+	FlagNameHTTPResponseHeaderTimeout = "http-response-header-timeout"
+	FlagNameMQTTConnectRetry          = "mqtt-connect-retry"
+	FlagNameMQTTConnectRetryInterval  = "mqtt-connect-retry-interval"
+	FlagNameMQTTAutoReconnect         = "mqtt-auto-reconnect"
+	FlagNameMQTTReconnectDelay        = "mqtt-reconnect-delay"
+	FlagNameMQTTConnectTimeout        = "mqtt-connect-timeout"
+	FlagNameMQTTPublishTimeout        = "mqtt-publish-timeout"
+	FlagNameMessageJournal            = "message-journal"
 )
 
 var DefaultConfig = Config{
@@ -83,6 +85,15 @@ type Config struct {
 	// HTTPTimeout is the duration the client will wait before cancelling an
 	// HTTP request.
 	HTTPTimeout time.Duration
+
+	// HTTPIdleConnTimeout is the maximum amount of time an idle (keep-alive)
+	// HTTP connection will remain idle before closing itself.
+	HTTPIdleConnTimeout time.Duration
+
+	// HTTPResponseHeaderTimeout is the maximum amount of time to wait for a
+	// server's response headers after fully writing the request (including its
+	// body). This time does not include the time to read the response body.
+	HTTPResponseHeaderTimeout time.Duration
 
 	// MQTTConnectRetry is the MQTT client option to enable connection retry
 	// logic when performing the initial connection.

--- a/internal/http/client.go
+++ b/internal/http/client.go
@@ -26,16 +26,31 @@ type Client struct {
 // NewHTTPClient creates a client with the given TLS configuration and
 // user-agent string.
 func NewHTTPClient(config *tls.Config, ua string) *Client {
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.TLSClientConfig = config.Clone()
+
 	client := http.Client{
-		Transport: http.DefaultTransport.(*http.Transport).Clone(),
+		Transport: transport,
 	}
-	client.Transport.(*http.Transport).TLSClientConfig = config.Clone()
 
 	return &Client{
 		Client:    client,
 		userAgent: ua,
 		Retries:   0,
 	}
+}
+
+// SetIdleConnTimeout sets the maximum amount of time an idle (keep-alive)
+// connection will remain idle before closing itself.
+func (c *Client) SetIdleConnTimeout(d time.Duration) {
+	c.Transport.(*http.Transport).IdleConnTimeout = d
+}
+
+// SetResponseHeaderTimeout sets the maximum amount of time to wait for a
+// server's response headers after fully writing the request (including its
+// body). This time does not include the time to read the response body.
+func (c *Client) SetResponseHeaderTimeout(d time.Duration) {
+	c.Transport.(*http.Transport).ResponseHeaderTimeout = d
 }
 
 func (c *Client) Get(url string) (*http.Response, error) {

--- a/internal/http/client_test.go
+++ b/internal/http/client_test.go
@@ -1,0 +1,27 @@
+package http
+
+import (
+	stdhttp "net/http"
+	"testing"
+	"time"
+)
+
+func TestSetIdleConnTimeout(t *testing.T) {
+	client := NewHTTPClient(nil, "test")
+	want := 42 * time.Second
+	client.SetIdleConnTimeout(want)
+	got := client.Transport.(*stdhttp.Transport).IdleConnTimeout
+	if got != want {
+		t.Errorf("SetIdleConnTimeout: got %v, want %v", got, want)
+	}
+}
+
+func TestSetResponseHeaderTimeout(t *testing.T) {
+	client := NewHTTPClient(nil, "test")
+	want := 15 * time.Second
+	client.SetResponseHeaderTimeout(want)
+	got := client.Transport.(*stdhttp.Transport).ResponseHeaderTimeout
+	if got != want {
+		t.Errorf("SetResponseHeaderTimeout: got %v, want %v", got, want)
+	}
+}

--- a/internal/transport/http.go
+++ b/internal/transport/http.go
@@ -27,16 +27,17 @@ type HTTPResponse struct {
 // HTTP is a Transporter that sends and receives data and control
 // messages by sending HTTP requests to a URL.
 type HTTP struct {
-	clientID        string
-	client          *internalhttp.Client
-	server          string
-	dataHandler     RxHandlerFunc
-	pollingInterval time.Duration
-	disconnected    atomic.Value
-	userAgent       string
-	isTLS           atomic.Value
-	events          chan TransporterEvent
-	eventHandler    EventHandlerFunc
+	clientID              string
+	client                *internalhttp.Client
+	responseHeaderTimeout time.Duration
+	server                string
+	dataHandler           RxHandlerFunc
+	pollingInterval       time.Duration
+	disconnected          atomic.Value
+	userAgent             string
+	isTLS                 atomic.Value
+	events                chan TransporterEvent
+	eventHandler          EventHandlerFunc
 }
 
 func NewHTTPTransport(
@@ -45,20 +46,24 @@ func NewHTTPTransport(
 	tlsConfig *tls.Config,
 	userAgent string,
 	pollingInterval time.Duration,
+	responseHeaderTimeout time.Duration,
 ) (*HTTP, error) {
 	disconnected := atomic.Value{}
 	disconnected.Store(false)
 	isTls := atomic.Value{}
 	isTls.Store(tlsConfig != nil)
+	client := internalhttp.NewHTTPClient(tlsConfig.Clone(), userAgent)
+	client.SetResponseHeaderTimeout(responseHeaderTimeout)
 	return &HTTP{
-		clientID:        clientID,
-		client:          internalhttp.NewHTTPClient(tlsConfig.Clone(), userAgent),
-		pollingInterval: pollingInterval,
-		disconnected:    disconnected,
-		server:          server,
-		userAgent:       userAgent,
-		isTLS:           isTls,
-		events:          make(chan TransporterEvent),
+		clientID:              clientID,
+		client:                client,
+		responseHeaderTimeout: responseHeaderTimeout,
+		pollingInterval:       pollingInterval,
+		disconnected:          disconnected,
+		server:                server,
+		userAgent:             userAgent,
+		isTLS:                 isTls,
+		events:                make(chan TransporterEvent),
 	}, nil
 }
 
@@ -142,9 +147,12 @@ func (t *HTTP) Connect() error {
 	return nil
 }
 
-// ReloadTLSConfig creates a new HTTP client with the provided TLS config.
+// ReloadTLSConfig creates a new HTTP client with the provided TLS config,
+// preserving any timeout settings stored on the transport.
 func (t *HTTP) ReloadTLSConfig(tlsConfig *tls.Config) error {
-	*t.client = *internalhttp.NewHTTPClient(tlsConfig, t.userAgent)
+	client := internalhttp.NewHTTPClient(tlsConfig, t.userAgent)
+	client.SetResponseHeaderTimeout(t.responseHeaderTimeout)
+	*t.client = *client
 	t.isTLS.Store(tlsConfig != nil)
 	return nil
 }

--- a/internal/transport/http_test.go
+++ b/internal/transport/http_test.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"net"
 	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"testing"
 	"time"
@@ -164,6 +165,7 @@ func TestTx(t *testing.T) {
 				nil,
 				"testUA",
 				time.Second,
+				0,
 			)
 			if err != nil {
 				t.Fatalf("cannot create new transport: %v", err)
@@ -193,5 +195,44 @@ func TestTx(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// TestReloadTLSConfigPreservesResponseHeaderTimeout verifies that the
+// responseHeaderTimeout set at construction is not lost when ReloadTLSConfig
+// replaces the internal HTTP client.
+func TestReloadTLSConfigPreservesResponseHeaderTimeout(t *testing.T) {
+	// Slow server: delays response headers long enough to reliably trigger a
+	// 1 ms ResponseHeaderTimeout.
+	slow := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(50 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer slow.Close()
+
+	ht, err := transport.NewHTTPTransport(
+		"test",
+		slow.Listener.Addr().String(),
+		nil,
+		"testUA",
+		time.Second,
+		time.Millisecond, // responseHeaderTimeout: 1 ms — fires before slow server responds
+	)
+	if err != nil {
+		t.Fatalf("cannot create transport: %v", err)
+	}
+
+	if _, _, _, err := ht.Tx("data", nil, []byte("x")); err == nil {
+		t.Fatal("expected timeout error before TLS reload, got nil")
+	}
+
+	if err := ht.ReloadTLSConfig(nil); err != nil {
+		t.Fatalf("ReloadTLSConfig: %v", err)
+	}
+
+	if _, _, _, err := ht.Tx("data", nil, []byte("x")); err == nil {
+		t.Fatal(
+			"expected timeout error after TLS reload, got nil — responseHeaderTimeout was not preserved",
+		)
 	}
 }


### PR DESCRIPTION
## Problem

When yggdrasil is used for MQTT-based Remote Execution (ReX) in
Foreman/Satellite, jobs frequently get stuck in **Pending** state even
though the host has successfully executed the job.

Investigation of the yggdrasil logs on an affected host revealed the
following pattern:

1. The host receives a job via MQTT and fetches its details with a `GET`
   to the smart proxy — this succeeds immediately (HTTP 200).
2. The host executes the job (e.g. a `dnf` package install taking
   several minutes).
3. The host sends a first `POST .../update` to report progress — this
   succeeds (HTTP 200).
4. Some time later (> 30 seconds after the previous request), the host
   sends a second `POST .../update` to report completion — **no response
   is ever logged, and yggd hangs indefinitely**.

Cross-referencing with the smart proxy access log confirmed that **the
second POST never arrived at the server**. The proxy logged a `Started`
and `Finished` entry for every request it received — the stuck POST left
no trace on the server side.

## Root cause

`foreman-proxy` uses WEBrick as its HTTP server, which has a default
`KeepAliveTimeout` of **30 seconds**. After 30 seconds of inactivity on
a keep-alive connection, WEBrick silently closes its end of the TCP
socket.

`NewHTTPClient` clones `http.DefaultTransport`, which has an
`IdleConnTimeout` of **90 seconds**. This means yggd considers
keep-alive connections valid for up to 90 seconds, well past the point
where the server has already closed them.

When the gap between two consecutive requests on the same connection
exceeds the server's keep-alive timeout, yggd writes into a dead socket.
In environments where the TCP RST/FIN from the server is dropped by an
intermediate network element (e.g. a NAT or container network bridge),
the Go HTTP client has no way to detect the dead connection and blocks
forever waiting for a response — because `http.Client.Timeout` is unset
(zero = no timeout).

This bug is specific to MQTT-based ReX because SSH-based ReX has the
proxy initiate the connection to the host directly; the host never needs
to POST results back. Only the pull-based (MQTT) flow requires the host
to make outbound HTTP calls to the proxy, exposing this failure mode.

## Fix

- Set `IdleConnTimeout` on the transport so that idle connections are
  proactively closed on the client side before the server's keep-alive
  timeout fires, avoiding the stale connection race.
- Set `Timeout` on the `http.Client` as a safety net: if a stale
  connection is reused anyway and the server never responds, the request
  fails with a timeout error instead of blocking indefinitely.

Both values are exposed as configurable options — `http-idle-conn-timeout`
and `http-timeout` respectively — following the existing convention for
HTTP and MQTT tuning knobs. `http-idle-conn-timeout` defaults to 30s.
`SetIdleConnTimeout` is introduced as a method on `Client` to allow
callers to apply the configured value without leaking transport
internals outside the package.

While the specific keep-alive timeout value of 30 seconds was observed
with WEBrick/foreman-proxy, the fix is not specific to that server —
setting a client-side idle timeout and a request timeout is correct
practice for any HTTP client.