### PR TITLE
refactor: Update paho-mqtt client to use CallbackAPIVersion.VERSION2

### DIFF
--- a/integration-tests/test_yggdrasil_default_facts_file.py
+++ b/integration-tests/test_yggdrasil_default_facts_file.py
@@ -101,7 +101,7 @@ def wait_for_canonical_facts(timeout: int = 30) -> dict:
 
     topic = f"{path_prefix}/{client_id}/control/out"
 
-    client = mqtt.Client()
+    client = mqtt.Client(callback_api_version=mqtt.CallbackAPIVersion.VERSION2)
     client.on_message = on_message
     client.connect(host, port, 60)
     client.subscribe(topic)


### PR DESCRIPTION
Fixes "DeprecationWarning: Callback API version 1 is deprecated, update to latest version"