### PR TITLE
fix: set HTTP client timeouts to prevent indefinite hangs

### DIFF
--- a/cmd/yggd/http.go
+++ b/cmd/yggd/http.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/redhatinsights/yggdrasil"
 	"github.com/subpop/go-log"
@@ -20,10 +21,15 @@ var (
 // initHTTPClient initializes the HTTP Client that is used by the get and post
 // functions.
 func initHTTPClient(config *tls.Config, ua string) {
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.TLSClientConfig = config
+	transport.IdleConnTimeout = 30 * time.Second
+	transport.ResponseHeaderTimeout = 30 * time.Second
+
 	client = &http.Client{
-		Transport: http.DefaultTransport.(*http.Transport).Clone(),
+		Transport: transport,
+		Timeout:   30 * time.Second,
 	}
-	client.Transport.(*http.Transport).TLSClientConfig = config
 
 	userAgent = ua
 }

--- a/cmd/yggd/http_test.go
+++ b/cmd/yggd/http_test.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestInitHTTPClientTimeouts(t *testing.T) {
+	initHTTPClient(nil, "test")
+
+	transport := client.Transport.(*http.Transport)
+	if transport.IdleConnTimeout != 30*time.Second {
+		t.Errorf("IdleConnTimeout: got %v, want %v", transport.IdleConnTimeout, 30*time.Second)
+	}
+	if transport.ResponseHeaderTimeout != 30*time.Second {
+		t.Errorf(
+			"ResponseHeaderTimeout: got %v, want %v",
+			transport.ResponseHeaderTimeout,
+			30*time.Second,
+		)
+	}
+	if client.Timeout != 30*time.Second {
+		t.Errorf("Timeout: got %v, want %v", client.Timeout, 30*time.Second)
+	}
+}
+
+func TestHTTPClientResponseHeaderTimeout(t *testing.T) {
+	slow := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(50 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer slow.Close()
+
+	initHTTPClient(nil, "test")
+	// Override to a short timeout to keep the test fast.
+	client.Transport.(*http.Transport).ResponseHeaderTimeout = time.Millisecond
+	client.Timeout = 0 // remove to isolate ResponseHeaderTimeout
+
+	if _, err := get(slow.URL); err == nil {
+		t.Fatal("expected timeout error, got nil")
+	}
+}


### PR DESCRIPTION
## Problem

When yggdrasil is used for MQTT-based Remote Execution (ReX) in
Foreman/Satellite, jobs can get stuck in **Pending** state because
yggd hangs indefinitely while trying to POST job results back to
the smart proxy.

The root cause is the same as #392 (fixed in main): `initHTTPClient`
creates an `http.Client` with no timeouts. When the server closes a
keep-alive connection after its keep-alive timeout fires, and the
TCP FIN/RST is dropped by an intermediate network element (e.g. a
NAT or container network bridge), the client has no way to detect
the dead connection and blocks forever.

## Fix

Set three timeouts in `initHTTPClient`:

- `IdleConnTimeout` (30s): proactively close idle connections before
  the server's keep-alive timeout fires, reducing the chance of
  reusing a stale connection.
- `ResponseHeaderTimeout` (30s): fail quickly if the server never
  sends response headers, rather than blocking indefinitely.
- `Timeout` (30s): safety net covering the full request lifecycle.

Unlike the main branch, all three timeouts are safe to set here
because the HTTP client in 0.2.x is only used for normal
request/response cycles (fetching detached job content and posting
results). The control plane is MQTT, so there is no long-polling
over HTTP to worry about.

## Notes

This is a backport of #392 to the 0.2.x series. The fix is simpler
here since there is a single shared HTTP client with one construction
site and no cert-reload path to worry about.
