### PR TITLE
test: mark integration tests with pytest tier1

### DIFF
--- a/integration-tests/conftest.py
+++ b/integration-tests/conftest.py
@@ -1,0 +1,2 @@
+def pytest_configure(config):
+    config.addinivalue_line("markers", "tier1: tier 1 integration tests")

--- a/integration-tests/test_echo_worker.py
+++ b/integration-tests/test_echo_worker.py
@@ -6,6 +6,8 @@ It indirectly tests that yggdrasil service dispatch MQTT message to
 import subprocess
 import logging
 import time
+import pytest
+
 from utils import loop_until, get_yggdrasil_client_id
 
 logger = logging.getLogger(__name__)
@@ -38,6 +40,7 @@ def is_echo_worker_running():
         return False
 
 
+@pytest.mark.tier1
 def test_echo_started_on_mqtt_message():
     """
     Test that echo worker service is automatically started,

--- a/integration-tests/test_local_privilege_escalation.py
+++ b/integration-tests/test_local_privilege_escalation.py
@@ -1,9 +1,11 @@
 import subprocess
 import logging
+import pytest
 
 logger = logging.getLogger(__name__)
 
 
+@pytest.mark.tier1
 def test_local_privilege_escalation():
     """
     :id: 09ca0098-6dcd-465b-9f10-262776b858b0

--- a/integration-tests/test_yggdrasil_default_facts_file.py
+++ b/integration-tests/test_yggdrasil_default_facts_file.py
@@ -10,6 +10,7 @@ from utils import (
 )
 
 
+@pytest.mark.tier1
 def test_yggdrasil_publishes_canonical_facts(external_candlepin, rhc, test_config):
     """
     :title: Verify Yggdrasil publishes canonical facts using default facts file.

--- a/integration-tests/test_yggdrasil_service.py
+++ b/integration-tests/test_yggdrasil_service.py
@@ -4,9 +4,12 @@ This Python module contains integration tests for yggdrasil service.
 
 import subprocess
 import logging
+import pytest
 
 logger = logging.getLogger(__name__)
 
+
+@pytest.mark.tier1
 def test_status_yggdrasil_service():
     """
     This test tries to get status of yggdrasil service
@@ -20,6 +23,8 @@ def test_status_yggdrasil_service():
     )
     assert "yggdrasil system service" in proc.stdout
 
+
+@pytest.mark.tier1
 def test_start_yggdrasil_service():
     """
     This test tries to start yggdrasil service
@@ -54,6 +59,8 @@ def test_start_yggdrasil_service():
     assert proc.stdout.strip() == "active"
     logger.info("The yggdrasil service was started")
 
+
+@pytest.mark.tier1
 def test_stop_yggdrasil_service():
     """
     This test tries to start and then stop yggdrasil service.


### PR DESCRIPTION
Register the `tier1` marker in `integration-tests/conftest.py` so pytest does not warn on unknown marks, and apply `@pytest.mark.tier1` to all integration tests.